### PR TITLE
Update the issue tracker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ actions via the discovery service's UI.
 
 ### Issue tracker
 
-See project [FOLIO](https://issues.folio.org/browse/FOLIO)
+See project [MODPATRON](https://issues.folio.org/browse/MODPATRON)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
 ### Other documentation

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   </scm>
   <issueManagement>
     <system>JIRA</system>
-    <url>https://issues.folio.org/projects/FOLIO</url>
+    <url>https://issues.folio.org/projects/MODPATRON</url>
   </issueManagement>
   <ciManagement>
     <system>Jenkins</system>


### PR DESCRIPTION
Now that there is a mod-patron JIRA project, we can update the links in the project. Fixes MODPATRON-1.