### PR TITLE
Support either circulation 3.3 or 4.0 interfaces MODPATRON-9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-## 1.0.1 Unreleased
+## 1.1.0 Unreleased
+
+* Requires either `circulation` 3.3 or 4.0 (MODPATRON-9, CIRC-136)
 
 ## 1.0.0 2018-08-17
  * Update the circulation dependency to 3.3 that contains the loan renew by id

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -64,7 +64,7 @@
     },
     {
       "id": "circulation",
-      "version": "3.3"
+      "version": "3.3 4.0"
     },
     {
       "id": "feesfines",

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-patron</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>Patron Services</name>
   <description>Discovery service initiated patron services for FOLIO</description>
   <inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
*Purpose*

Purpose

https://issues.folio.org/browse/MODRTAC-3
https://issues.folio.org/browse/CIRC-136
https://issues.folio.org/browse/CIRCSTORE-71

In order to support anonymization of loans the relationship between a loan and a user needs to be optional for closed loans.

This change requires making the userId property in the loan schema optional which is a potentially compatibility breaking change.

*Approach*

* Investigated the code for uses of `userId` from a loan (couldn't find any)
* Changed the interface requirements in the module descriptor to support both 3.0 and 4.0 or greater
* Changed the implementation version (and news) to reflect this (minor increment, and there does not appear to be any changes since the last release, 1.0.1)

*Limitations*

* I wasn't able to test registration of the module with Okapi proxy locally, as this requires dependencies to also be registered, and I don't have mod-feesfines set up locally.