### PR TITLE
Update the feesfines interface version (MODPATRON-16)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 1.2.0 Unreleased
+ * Requires either `feesfines` 14.0 or 15.0 (MODPATRON-16)
  * Update schema files with a top level description (MODPATRON-11)
  * Requires either `circulation` 3.3, 4.0 or 5.0 (MODPATRON-12)
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -68,7 +68,7 @@
     },
     {
       "id": "feesfines",
-      "version": "14.0"
+      "version": "14.0 15.0"
     },
     {
       "id": "inventory",


### PR DESCRIPTION
It is not clear why the interface version has been updated to 15.0, perhaps to match the package version? Whatever the reason, the APIs and JSON schemas mod-patron uses have not changed in many months.