### PR TITLE
Include 6.0 in supported circulation versions MODPATRON-17

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -64,7 +64,7 @@
     },
     {
       "id": "circulation",
-      "version": "3.3 4.0 5.0"
+      "version": "3.3 4.0 5.0 6.0"
     },
     {
       "id": "feesfines",


### PR DESCRIPTION
As it does not use the rules related endpoints changed in version 6.0