### PR TITLE
MODPATRON-2: add request queue position to the hold (request)

### DIFF
--- a/ramls/examples/account.json
+++ b/ramls/examples/account.json
@@ -33,6 +33,7 @@
         "title": "I Want to Hold Your Hand",
         "author": "John Lennon; Paul McCartney"
       },
+      "queuePosition": 1,
       "requestDate": "2018-06-02T08:16:30Z",
       "pickupLocationId": "ebab9ccc-4ece-4f35-bc82-01f3325abed8",
       "status": "Open - Not yet filled"

--- a/ramls/examples/hold.json
+++ b/ramls/examples/hold.json
@@ -6,6 +6,7 @@
     "title": "Something's Got a Hold on Me",
     "author": "Etta James; Leroy Kirkland; Pearl Woods"
   },
+  "queuePosition": 1,
   "requestDate": "2018-06-02T08:16:30Z",
   "expirationDate": "3000-01-30T08:16:30Z",
   "pickupLocationId": "ebab9ccc-4ece-4f35-bc82-01f3325abed8",

--- a/ramls/hold.json
+++ b/ramls/hold.json
@@ -41,10 +41,6 @@
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
       "description": "The UUID of the pick up location"
     },
-    "queueLength": {
-      "type": "integer",
-      "description": "The number of patrons with holds on this item"
-    },
     "queuePosition": {
       "type": "integer",
       "description": "The position in the queue for this patron"

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -49,6 +49,7 @@ public class PatronServicesResourceImpl implements Patron {
   private static final String JSON_FIELD_USER_ID = "userId";
   private static final String JSON_FIELD_ITEM_ID = "itemId";
   private static final String JSON_FIELD_REQUEST_EXPIRATION_DATE = "requestExpirationDate";
+  private static final String JSON_FIELD_POSITION = "position";
   private static final String JSON_VALUE_HOLD_SHELF = "Hold Shelf";
 
   @Validate
@@ -74,7 +75,7 @@ public class PatronServicesResourceImpl implements Patron {
                 .thenApply(this::verifyAndExtractBody)
                 .thenApply(body -> addLoans(account, body, includeLoans));
 
-            final CompletableFuture<Account> cf2 = httpClient.request("/circulation/requests?limit=" + getLimit(includeHolds) + "&query=%28requesterId%3D%3D" + id + "%20and%20requestType%3D%3DHold%20and%20status%3D%3DOpen%2A%29", okapiHeaders)
+            final CompletableFuture<Account> cf2 = httpClient.request("/circulation/requests?limit=" + getLimit(includeHolds) + "&query=%28requesterId%3D%3D" + id + "%20and%20status%3D%3DOpen%2A%29", okapiHeaders)
                 .thenApply(this::verifyAndExtractBody)
                 .thenApply(body -> addHolds(account, body, includeHolds));
 
@@ -364,6 +365,7 @@ public class PatronServicesResourceImpl implements Patron {
         .withRequestId(holdJson.getString("id"))
         .withPickupLocationId(holdJson.getString(JSON_FIELD_PICKUP_SERVICE_POINT_ID))
         .withRequestDate(new DateTime(holdJson.getString(JSON_FIELD_REQUEST_DATE), DateTimeZone.UTC).toDate())
+        .withQueuePosition(holdJson.getInteger(JSON_FIELD_POSITION))
         .withStatus(Status.fromValue(holdJson.getString("status")));
   }
 

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -179,12 +179,12 @@ public class PatronResourceImplTest {
               .end(readMockFile(mockDataFolder + "/holds_create.json"));
           }
         } else {
-          if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20requestType%%3D%%3DHold%%20and%%20status%%3D%%3DOpen%%2A%%29", Integer.MAX_VALUE, goodUserId))) {
+          if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20status%%3D%%3DOpen%%2A%%29", Integer.MAX_VALUE, goodUserId))) {
             req.response()
               .setStatusCode(200)
               .putHeader("content-type", "application/json")
               .end(readMockFile(mockDataFolder + "/holds_all.json"));
-          } else if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20requestType%%3D%%3DHold%%20and%%20status%%3D%%3DOpen%%2A%%29", 1, goodUserId))) {
+          } else if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20status%%3D%%3DOpen%%2A%%29", 1, goodUserId))) {
             req.response()
               .setStatusCode(200)
               .putHeader("content-type", "application/json")
@@ -984,7 +984,8 @@ public class PatronResourceImplTest {
       assertEquals(expectedHold.getString("status"), actualHold.getString("status"));
       assertEquals(expectedHold.getString("expirationDate") == null ? null : new DateTime(expectedHold.getString("expirationDate"), DateTimeZone.UTC),
           actualHold.getString("expirationDate") == null ? null : new DateTime(actualHold.getString("expirationDate"), DateTimeZone.UTC));
-
+      assertEquals(expectedHold.getInteger("requestPosition"),
+          actualHold.getInteger("requestPosition"));
       return verifyItem(expectedHold.getJsonObject("item"), actualHold.getJsonObject("item"));
     }
 

--- a/src/test/resources/PatronServicesResourceImpl/holds_all.json
+++ b/src/test/resources/PatronServicesResourceImpl/holds_all.json
@@ -8,6 +8,7 @@
       "requestDate": "2018-06-02T08:16:30Z",
       "fulfilmentPreference": "Hold Shelf",
       "status": "Open - Not yet filled",
+      "position": 1,
       "item" :{
         "title": "I Want to Hold Your Hand",
         "instanceId": "255f82f3-5b1b-4239-93e4-ec6acf03ad9d",
@@ -25,6 +26,7 @@
       "requestDate": "2018-05-01T05:01:15Z",
       "fulfilmentPreference": "Hold Shelf",
       "status": "Open - Awaiting pickup",
+      "position": 3,
       "item" :{
         "title": "Hold On",
         "instanceId": "0b559683-9059-4b6d-bb6a-c55aa3518df3",
@@ -44,6 +46,7 @@
       "fulfilmentPreference": "Hold Shelf",
       "status": "Open - Not yet filled",
       "requestExpirationDate": "2020-01-31T15:22:12Z",
+      "position": 5,
       "item" :{
         "title": "Hold On, I'm Comin'",
         "instanceId": "4bb0fffc-fe55-4445-819d-9bc5b8cd47ef",

--- a/src/test/resources/PatronServicesResourceImpl/holds_create.json
+++ b/src/test/resources/PatronServicesResourceImpl/holds_create.json
@@ -7,6 +7,7 @@
   "requestExpirationDate": "3000-01-30T08:16:30Z",
   "fulfilmentPreference": "Hold Shelf",
   "status": "Open - Not yet filled",
+  "position": 1,
   "item" :{
     "title": "Something's Got a Hold on Me",
     "instanceId": "23611f0b-35cc-4f40-af09-75907d7cc421",

--- a/src/test/resources/PatronServicesResourceImpl/instance_holds_create.json
+++ b/src/test/resources/PatronServicesResourceImpl/instance_holds_create.json
@@ -7,6 +7,7 @@
   "requestExpirationDate": "3000-01-30T08:16:30Z",
   "fulfilmentPreference": "Hold Shelf",
   "status": "Open - Not yet filled",
+  "position": 1,
   "item" :{
     "title": "Something's Got a Hold on Me",
     "instanceId": "23611f0b-35cc-4f40-af09-75907d7cc421",

--- a/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById.json
@@ -78,6 +78,7 @@
                 "title": "I Want to Hold Your Hand",
                 "author": "John Lennon; Paul McCartney"
             },
+            "queuePosition": 1,
             "fulfillmentPreference": "Hold Shelf",
             "status": "Open - Not yet filled"
         },
@@ -89,6 +90,7 @@
                 "title": "Hold On",
                 "author": "Jon Anderson; Trevor Rabin; Chris Squire"
             },
+            "queuePosition": 3,
             "fulfillmentPreference": "Hold Shelf",
             "status": "Open - Awaiting pickup"
         },
@@ -100,6 +102,7 @@
                 "title": "Hold On, I'm Comin'",
                 "author": "Isaac Hayes; David Porter"
             },
+            "queuePosition": 5,
             "expirationDate": "2020-01-31T15:22:12Z",
             "fulfillmentPreference": "Hold Shelf",
             "status": "Open - Not yet filled"

--- a/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdInstanceByInstanceIdHold.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdInstanceByInstanceIdHold.json
@@ -7,6 +7,7 @@
         "title": "Something's Got a Hold on Me",
         "author": "Etta James; Leroy Kirkland; Pearl Woods"
     },
+    "queuePosition": 1,
     "expirationDate": "3000-01-30T08:16:30Z",
     "status": "Open - Not yet filled",
     "pickupLocationId": "963396d7-c96f-4bb1-a24c-42e868a8823d"

--- a/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdItemByItemIdHold.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdItemByItemIdHold.json
@@ -6,6 +6,7 @@
         "title": "Something's Got a Hold on Me",
         "author": "Etta James; Leroy Kirkland; Pearl Woods"
     },
+    "queuePosition": 1,
     "expirationDate": "3000-01-30T08:16:30Z",
     "status": "Open - Not yet filled",
     "pickupLocationId": "963396d7-c96f-4bb1-a24c-42e868a8823d"


### PR DESCRIPTION
When returning the request details in a patron account request or hold request, we now return the request queue position.

Also, the "requestLength" JSON field was removed as it is not necessary at this time and probably never will be.

Finally, altered the FOLIO request query to return all requests, not just holds. This way, the client will be able to see page and recalls as well, though the client (a discovery service) will not be able to distinguish between the request types.