### PR TITLE
MODPATRON-25: remove some validation restrictions

### DIFF
--- a/ramls/hold.json
+++ b/ramls/hold.json
@@ -3,11 +3,10 @@
   "title": "Patron Hold Schema",
   "type": "object",
   "description": "Hold schema for patron portal integration",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "requestId": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
       "description": "The UUID of the request"
     },
     "item": {


### PR DESCRIPTION
This is a temporary measure in order to integrate with a currently deployed discovery service.