### PR TITLE
MODPATRON-26

### DIFF
--- a/src/main/java/org/folio/rest/impl/Constants.java
+++ b/src/main/java/org/folio/rest/impl/Constants.java
@@ -1,0 +1,19 @@
+package org.folio.rest.impl;
+
+class Constants {
+  static final String JSON_FIELD_PICKUP_SERVICE_POINT_ID = "pickupServicePointId";
+  static final String JSON_FIELD_REQUEST_DATE = "requestDate";
+  static final String JSON_FIELD_NAME = "name";
+  static final String JSON_FIELD_ITEM = "item";
+  static final String JSON_FIELD_TOTAL_RECORDS = "totalRecords";
+  static final String JSON_FIELD_CONTRIBUTORS = "contributors";
+  static final String JSON_FIELD_TITLE = "title";
+  static final String JSON_FIELD_INSTANCE_ID = "instanceId";
+  static final String JSON_FIELD_USER_ID = "userId";
+  static final String JSON_FIELD_ITEM_ID = "itemId";
+  static final String JSON_FIELD_REQUEST_EXPIRATION_DATE = "requestExpirationDate";
+  static final String JSON_FIELD_POSITION = "position";
+  static final String JSON_VALUE_HOLD_SHELF = "Hold Shelf";
+  static final String JSON_FIELD_ID = "id";
+  static final String JSON_FIELD_PATRON_GROUP = "patronGroup";
+}

--- a/src/main/java/org/folio/rest/impl/Constants.java
+++ b/src/main/java/org/folio/rest/impl/Constants.java
@@ -1,6 +1,9 @@
 package org.folio.rest.impl;
 
 class Constants {
+
+  private Constants(){}
+
   static final String JSON_FIELD_PICKUP_SERVICE_POINT_ID = "pickupServicePointId";
   static final String JSON_FIELD_REQUEST_DATE = "requestDate";
   static final String JSON_FIELD_NAME = "name";

--- a/src/main/java/org/folio/rest/impl/ItemStatus.java
+++ b/src/main/java/org/folio/rest/impl/ItemStatus.java
@@ -1,9 +1,6 @@
 package org.folio.rest.impl;
 
-
 import java.util.Arrays;
-
-import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 public enum ItemStatus {
   NONE(""),
@@ -34,6 +31,6 @@ public enum ItemStatus {
   }
 
   private boolean valueMatches(String value) {
-    return equalsIgnoreCase(getValue(), value);
+    return this.value.equalsIgnoreCase(value);
   }
 }

--- a/src/main/java/org/folio/rest/impl/ItemStatus.java
+++ b/src/main/java/org/folio/rest/impl/ItemStatus.java
@@ -1,0 +1,39 @@
+package org.folio.rest.impl;
+
+
+import java.util.Arrays;
+
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+
+public enum ItemStatus {
+  NONE(""),
+  AVAILABLE("Available"),
+  AWAITING_PICKUP("Awaiting pickup"),
+  CHECKED_OUT("Checked out"),
+  IN_TRANSIT("In transit"),
+  MISSING("Missing"),
+  PAGED("Paged"),
+  ON_ORDER("On order"),
+  IN_PROCESS("In process");
+
+  public static ItemStatus from(String value) {
+    return Arrays.stream(values())
+      .filter(status -> status.valueMatches(value))
+      .findFirst()
+      .orElse(NONE);
+  }
+
+  private final String value;
+
+  ItemStatus(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  private boolean valueMatches(String value) {
+    return equalsIgnoreCase(getValue(), value);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -1,0 +1,66 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.patron.rest.exceptions.HttpException;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.client.HttpClientFactory;
+import org.folio.rest.tools.client.Response;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+import org.folio.rest.tools.utils.TenantTool;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+class LookupsUtils {
+
+  static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders) {
+    HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+    return get("/inventory/items/" + itemId, httpClient, okapiHeaders)
+      .thenApply(LookupsUtils::verifyAndExtractBody);
+  }
+
+  static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
+    HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+    return get("/users/" + userId, httpClient, okapiHeaders)
+      .thenApply(LookupsUtils::verifyAndExtractBody);
+  }
+
+  static CompletableFuture<JsonObject> getRequestPolicyId(String queryString, Map<String, String> okapiHeaders) {
+    HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+    return get("/circulation/rules/request-policy?" + queryString, httpClient, okapiHeaders)
+      .thenApply(LookupsUtils::verifyAndExtractBody);
+  }
+
+  static CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders) {
+    HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+    return get("/request-policy-storage/request-policies/" + requestPolicyId, httpClient, okapiHeaders)
+      .thenApply(LookupsUtils::verifyAndExtractBody);
+  }
+
+  static JsonObject verifyAndExtractBody(Response response) {
+    if (!Response.isSuccess(response.getCode())) {
+      throw new CompletionException(new HttpException(response.getCode(),
+        response.getError().getString("errorMessage")));
+    }
+
+    return response.getBody();
+  }
+
+  static HttpClientInterface getHttpClient(Map<String, String> okapiHeaders) {
+    final String okapiURL = okapiHeaders.getOrDefault("X-Okapi-Url", "");
+    final String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
+
+    return HttpClientFactory.getHttpClient(okapiURL, tenantId);
+  }
+
+  private static CompletableFuture<Response> get (String path,
+                                                        HttpClientInterface httpClient,
+                                                        Map<String, String> okapiHeaders) {
+    try {
+      return httpClient.request(path, okapiHeaders);
+    } catch (Exception e) {
+      throw new CompletionException(e);
+    }
+  }
+}

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -14,6 +14,8 @@ import java.util.concurrent.CompletionException;
 
 class LookupsUtils {
 
+  private LookupsUtils(){}
+
   static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders) {
     HttpClientInterface httpClient = getHttpClient(okapiHeaders);
     return get("/inventory/items/" + itemId, httpClient, okapiHeaders)

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -16,26 +16,26 @@ class LookupsUtils {
 
   private LookupsUtils(){}
 
-  static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders) {
-    HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+  static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders,
+                                               HttpClientInterface httpClient) {
     return get("/inventory/items/" + itemId, httpClient, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
-    HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+  static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders,
+                                               HttpClientInterface httpClient) {
     return get("/users/" + userId, httpClient, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static CompletableFuture<JsonObject> getRequestPolicyId(String queryString, Map<String, String> okapiHeaders) {
-    HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+  static CompletableFuture<JsonObject> getRequestPolicyId(String queryString, Map<String, String> okapiHeaders,
+                                                          HttpClientInterface httpClient) {
     return get("/circulation/rules/request-policy?" + queryString, httpClient, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders) {
-    HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+  static CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders,
+                                                        HttpClientInterface httpClient) {
     return get("/request-policy-storage/request-policies/" + requestPolicyId, httpClient, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -133,18 +133,14 @@ public class PatronServicesResourceImpl implements Patron {
       .thenCompose(holdJSON -> {
         try {
           if (holdJSON == null) {
-
-            final Errors errors = new Errors();
-
-            Error anError = new Error();
-            anError.setMessage("Cannot find a valid request type for this item");
-
-            Parameter parameter = new Parameter();
-            parameter.setKey("itemId");
-            parameter.setValue(itemId);
-
-            anError.setParameters(new ArrayList<>(Arrays.asList(parameter)));
-            errors.setErrors(new ArrayList<>( Arrays.asList(anError)));
+            final Errors errors = new Errors()
+                          .withErrors(Collections.singletonList(
+                              new Error().withMessage("Cannot find a valid request type for this item")
+                                         .withParameters(Collections.singletonList(
+                                            new Parameter().withKey("itemId")
+                                                           .withValue(itemId)
+                                         ))
+                          ));
 
             Throwable throwable = new Throwable((new HttpException(422, JsonObject.mapFrom(errors).toString())));
             asyncResultHandler.handle(handleItemHoldPOSTError(throwable));

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -391,7 +391,7 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<Account> lookupItem(HttpClientInterface httpClient, Charge charge, Account account, Map<String, String> okapiHeaders) {
-    return getItem(charge, httpClient, okapiHeaders)
+    return getItem(charge, okapiHeaders)
         .thenCompose(item ->getHoldingsRecord(item, httpClient, okapiHeaders))
         .thenApply(LookupsUtils::verifyAndExtractBody)
         .thenCompose(holding -> getInstance(holding, httpClient, okapiHeaders))
@@ -400,8 +400,7 @@ public class PatronServicesResourceImpl implements Patron {
         .thenApply(item -> updateItem(charge, item, account));
   }
 
-  private CompletableFuture<JsonObject> getItem(Charge charge,
-      HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
+  private CompletableFuture<JsonObject> getItem(Charge charge, Map<String, String> okapiHeaders) {
 
     return LookupsUtils.getItem(charge.getItem().getItemId(), okapiHeaders);
   }

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -142,8 +142,7 @@ public class PatronServicesResourceImpl implements Patron {
                                          ))
                           ));
 
-            Throwable throwable = new Throwable((new HttpException(422, JsonObject.mapFrom(errors).toString())));
-            asyncResultHandler.handle(handleItemHoldPOSTError(throwable));
+            asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountItemHoldByIdAndItemIdResponse.respond422WithApplicationJson(errors)));
             httpClient.closeClient();
             return null;
           }
@@ -516,10 +515,6 @@ public class PatronServicesResourceImpl implements Patron {
         break;
       case 404:
         result = Future.succeededFuture(PostPatronAccountItemHoldByIdAndItemIdResponse.respond404WithTextPlain(message));
-        break;
-      case 422:
-        final Errors errors = Json.decodeValue(message, Errors.class);
-        result = Future.succeededFuture(PostPatronAccountItemHoldByIdAndItemIdResponse.respond422WithApplicationJson(errors));
         break;
       default:
         result = Future.succeededFuture(PostPatronAccountItemHoldByIdAndItemIdResponse.respond500WithTextPlain(message));

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletionException;
 
 import org.folio.patron.rest.exceptions.HttpException;
 import org.folio.patron.rest.exceptions.ModuleGeneratedHttpException;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Account;
 import org.folio.rest.jaxrs.model.Charge;
@@ -20,10 +19,8 @@ import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.Loan;
 import org.folio.rest.jaxrs.model.TotalCharges;
 import org.folio.rest.jaxrs.resource.Patron;
-import org.folio.rest.tools.client.HttpClientFactory;
 import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
-import org.folio.rest.tools.utils.TenantTool;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -38,19 +35,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class PatronServicesResourceImpl implements Patron {
-  private static final String JSON_FIELD_PICKUP_SERVICE_POINT_ID = "pickupServicePointId";
-  private static final String JSON_FIELD_REQUEST_DATE = "requestDate";
-  private static final String JSON_FIELD_NAME = "name";
-  private static final String JSON_FIELD_ITEM = "item";
-  private static final String JSON_FIELD_TOTAL_RECORDS = "totalRecords";
-  private static final String JSON_FIELD_CONTRIBUTORS = "contributors";
-  private static final String JSON_FIELD_TITLE = "title";
-  private static final String JSON_FIELD_INSTANCE_ID = "instanceId";
-  private static final String JSON_FIELD_USER_ID = "userId";
-  private static final String JSON_FIELD_ITEM_ID = "itemId";
-  private static final String JSON_FIELD_REQUEST_EXPIRATION_DATE = "requestExpirationDate";
-  private static final String JSON_FIELD_POSITION = "position";
-  private static final String JSON_VALUE_HOLD_SHELF = "Hold Shelf";
 
   @Validate
   @Override
@@ -58,11 +42,10 @@ public class PatronServicesResourceImpl implements Patron {
       boolean includeCharges, boolean includeHolds,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
-    final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+    final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     try {
       // Look up the user to ensure that the user exists and is enabled
-      httpClient.request("/users/" + id, okapiHeaders)
-        .thenApply(this::verifyAndExtractBody)
+        LookupsUtils.getUser(id, okapiHeaders)
         .thenAccept(this::verifyUserEnabled)
         .thenCompose(v -> {
           try {
@@ -72,15 +55,15 @@ public class PatronServicesResourceImpl implements Patron {
             account.setTotalChargesCount(0);
 
             final CompletableFuture<Account> cf1 = httpClient.request("/circulation/loans?limit=" + getLimit(includeLoans) + "&query=%28userId%3D%3D" + id + "%20and%20status.name%3D%3DOpen%29", okapiHeaders)
-                .thenApply(this::verifyAndExtractBody)
+                .thenApply(LookupsUtils::verifyAndExtractBody)
                 .thenApply(body -> addLoans(account, body, includeLoans));
 
             final CompletableFuture<Account> cf2 = httpClient.request("/circulation/requests?limit=" + getLimit(includeHolds) + "&query=%28requesterId%3D%3D" + id + "%20and%20status%3D%3DOpen%2A%29", okapiHeaders)
-                .thenApply(this::verifyAndExtractBody)
+                .thenApply(LookupsUtils::verifyAndExtractBody)
                 .thenApply(body -> addHolds(account, body, includeHolds));
 
             final CompletableFuture<Account> cf3 = httpClient.request("/accounts?limit=" + getLimit(true) + "&query=%28userId%3D%3D" + id + "%20and%20status.name%3D%3DOpen%29", okapiHeaders)
-                .thenApply(this::verifyAndExtractBody)
+                .thenApply(LookupsUtils::verifyAndExtractBody)
                 .thenApply(body -> addCharges(account, body, includeCharges))
                 .thenCompose(charges -> {
                   if (includeCharges) {
@@ -121,15 +104,15 @@ public class PatronServicesResourceImpl implements Patron {
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     final JsonObject renewalJSON = new JsonObject()
-        .put(JSON_FIELD_ITEM_ID, itemId)
-        .put(JSON_FIELD_USER_ID, id);
+        .put(Constants.JSON_FIELD_ITEM_ID, itemId)
+        .put(Constants.JSON_FIELD_USER_ID, id);
 
-    final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+    final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     try {
       httpClient.request(HttpMethod.POST, Buffer.buffer(renewalJSON.toString()), "/circulation/renew-by-id", okapiHeaders)
-          .thenApply(this::verifyAndExtractBody)
+          .thenApply(LookupsUtils::verifyAndExtractBody)
           .thenAccept(body -> {
-            final Item item = getItem(itemId, body.getJsonObject(JSON_FIELD_ITEM));
+            final Item item = getItem(itemId, body.getJsonObject(Constants.JSON_FIELD_ITEM));
             final Loan hold = getLoan(body, item);
             asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountItemRenewByIdAndItemIdResponse.respond201WithApplicationJson(hold)));
             httpClient.closeClient();
@@ -150,38 +133,38 @@ public class PatronServicesResourceImpl implements Patron {
   public void postPatronAccountItemHoldByIdAndItemId(String id, String itemId,
       Hold entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
-    final JsonObject holdJSON = new JsonObject()
-        .put(JSON_FIELD_ITEM_ID, itemId)
-        .put("requesterId", id)
-        .put("requestType", "Hold")
-        .put(JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
-        .put("fulfilmentPreference", JSON_VALUE_HOLD_SHELF)
-        .put(JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId());
 
-    if (entity.getExpirationDate() != null) {
-      holdJSON.put(JSON_FIELD_REQUEST_EXPIRATION_DATE,
-          new DateTime(entity.getExpirationDate(), DateTimeZone.UTC).toString());
-    }
+    final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
+    RequestObjectFactory requestFactory = new RequestObjectFactory(okapiHeaders);
 
-    final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
-    try {
-      httpClient.request(HttpMethod.POST, Buffer.buffer(holdJSON.toString()), "/circulation/requests", okapiHeaders)
-          .thenApply(this::verifyAndExtractBody)
-          .thenAccept(body -> {
-            final Item item = getItem(itemId, body.getJsonObject(JSON_FIELD_ITEM));
-            final Hold hold = getHold(body, item);
-            asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountItemHoldByIdAndItemIdResponse.respond201WithApplicationJson(hold)));
-            httpClient.closeClient();
-          })
-          .exceptionally(throwable -> {
-            asyncResultHandler.handle(handleItemHoldPOSTError(throwable));
+    requestFactory.createRequestByItem(id, itemId, entity)
+      .thenCompose(holdJSON -> {
+        try {
+          if (holdJSON == null) {
+            asyncResultHandler.handle(handleItemHoldPOSTError(new Exception("Cannot find a valid request type for this item")));
             httpClient.closeClient();
             return null;
-          });
-    } catch (Exception e) {
-      asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountItemHoldByIdAndItemIdResponse.respond500WithTextPlain(e.getMessage())));
-      httpClient.closeClient();
-    }
+          }
+
+          return httpClient.request(HttpMethod.POST, Buffer.buffer(holdJSON.toString()), "/circulation/requests", okapiHeaders)
+            .thenApply(LookupsUtils::verifyAndExtractBody)
+            .thenAccept(body -> {
+              final Item item = getItem(itemId, body.getJsonObject(Constants.JSON_FIELD_ITEM));
+              final Hold hold = getHold(body, item);
+              asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountItemHoldByIdAndItemIdResponse.respond201WithApplicationJson(hold)));
+              httpClient.closeClient();
+            })
+            .exceptionally(throwable -> {
+              asyncResultHandler.handle(handleItemHoldPOSTError(throwable));
+              httpClient.closeClient();
+              return null;
+            });
+        } catch (Exception e) {
+          asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountItemHoldByIdAndItemIdResponse.respond500WithTextPlain(e.getMessage())));
+          httpClient.closeClient();
+          return null;
+        }
+      });
   }
 
   @Validate
@@ -198,10 +181,10 @@ public class PatronServicesResourceImpl implements Patron {
       String itemId, String holdId, Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     // Consider validation to verify the hold is for the specified user and the specified item.
-    final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+    final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     try {
       httpClient.request(HttpMethod.DELETE, "/circulation/requests/" + holdId, okapiHeaders)
-          .thenApply(this::verifyAndExtractBody)
+          .thenApply(LookupsUtils::verifyAndExtractBody)
           .thenAccept(body -> asyncResultHandler.handle(Future.succeededFuture(DeletePatronAccountItemHoldByIdAndItemIdAndHoldIdResponse.respond204())))
           .exceptionally(throwable -> {
             asyncResultHandler.handle(handleHoldDELETEError(throwable));
@@ -221,24 +204,24 @@ public class PatronServicesResourceImpl implements Patron {
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler,
       Context vertxContext) {
     final JsonObject holdJSON = new JsonObject()
-        .put(JSON_FIELD_INSTANCE_ID, instanceId)
+        .put(Constants.JSON_FIELD_INSTANCE_ID, instanceId)
         .put("requesterId", id)
-        .put(JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
-        .put(JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId());
+        .put(Constants.JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
+        .put(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId());
 
     if (entity.getExpirationDate() != null) {
-      holdJSON.put(JSON_FIELD_REQUEST_EXPIRATION_DATE,
+      holdJSON.put(Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE,
           new DateTime(entity.getExpirationDate(), DateTimeZone.UTC).toString());
     }
 
-    final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+    final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     try {
       httpClient.request(HttpMethod.POST, Buffer.buffer(holdJSON.toString()),
           "/circulation/requests/instances", okapiHeaders)
-          .thenApply(this::verifyAndExtractBody)
+          .thenApply(LookupsUtils::verifyAndExtractBody)
           .thenAccept(body -> {
-            final Item item = getItem(body.getString(JSON_FIELD_ITEM_ID),
-                body.getJsonObject(JSON_FIELD_ITEM));
+            final Item item = getItem(body.getString(Constants.JSON_FIELD_ITEM_ID),
+                body.getJsonObject(Constants.JSON_FIELD_ITEM));
             final Hold hold = getHold(body, item);
             asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountInstanceHoldByIdAndInstanceIdResponse.respond201WithApplicationJson(hold)));
             httpClient.closeClient();
@@ -254,13 +237,6 @@ public class PatronServicesResourceImpl implements Patron {
     }
   }
 
-  private HttpClientInterface getHttpClient(Map<String, String> okapiHeaders) {
-    final String okapiURL = okapiHeaders.getOrDefault("X-Okapi-Url", "");
-    final String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
-
-    return HttpClientFactory.getHttpClient(okapiURL, tenantId);
-  }
-
   private void verifyUserEnabled(JsonObject body) {
     final boolean active = body.getBoolean("active");
 
@@ -270,7 +246,7 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private Account addLoans(Account account, JsonObject body, boolean includeLoans) {
-    final int totalLoans = body.getInteger(JSON_FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
+    final int totalLoans = body.getInteger(Constants.JSON_FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
     final List<Loan> loans = new ArrayList<>();
 
     account.setTotalLoans(totalLoans);
@@ -281,7 +257,8 @@ public class PatronServicesResourceImpl implements Patron {
       for (Object o : loansArray) {
         if (o instanceof JsonObject) {
           JsonObject loanObject = (JsonObject) o;
-          final Item item = getItem(loanObject.getString(JSON_FIELD_ITEM_ID), loanObject.getJsonObject(JSON_FIELD_ITEM));
+          final Item item = getItem(loanObject.getString(Constants.JSON_FIELD_ITEM_ID),
+                                    loanObject.getJsonObject(Constants.JSON_FIELD_ITEM));
           final Loan loan = getLoan(loanObject, item);
           loans.add(loan);
         }
@@ -292,7 +269,7 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private Item getItem(String itemId, JsonObject itemJson) {
-    final JsonArray contributors = itemJson.getJsonArray(JSON_FIELD_CONTRIBUTORS, new JsonArray());
+    final JsonArray contributors = itemJson.getJsonArray(Constants.JSON_FIELD_CONTRIBUTORS, new JsonArray());
     final StringBuilder sb = new StringBuilder();
 
     for (Object o : contributors) {
@@ -300,15 +277,15 @@ public class PatronServicesResourceImpl implements Patron {
         if (sb.length() != 0) {
           sb.append("; ");
         }
-        sb.append(((JsonObject) o).getString(JSON_FIELD_NAME));
+        sb.append(((JsonObject) o).getString(Constants.JSON_FIELD_NAME));
       }
     }
 
     return new Item()
         .withAuthor(sb.length() == 0 ? null : sb.toString())
-        .withInstanceId(itemJson.getString(JSON_FIELD_INSTANCE_ID))
+        .withInstanceId(itemJson.getString(Constants.JSON_FIELD_INSTANCE_ID))
         .withItemId(itemId)
-        .withTitle(itemJson.getString(JSON_FIELD_TITLE));
+        .withTitle(itemJson.getString(Constants.JSON_FIELD_TITLE));
   }
 
   private Loan getLoan(JsonObject loan, Item item) {
@@ -337,7 +314,7 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private Account addHolds(Account account, JsonObject body, boolean includeHolds) {
-    final int totalHolds = body.getInteger(JSON_FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
+    final int totalHolds = body.getInteger(Constants.JSON_FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
     final List<Hold> holds = new ArrayList<>();
 
     account.setTotalHolds(totalHolds);
@@ -348,7 +325,7 @@ public class PatronServicesResourceImpl implements Patron {
       for (Object o : holdsJson) {
         if (o instanceof JsonObject) {
           JsonObject holdJson = (JsonObject) o;
-          final Item item = getItem(holdJson.getString(JSON_FIELD_ITEM_ID), holdJson.getJsonObject(JSON_FIELD_ITEM));
+          final Item item = getItem(holdJson.getString(Constants.JSON_FIELD_ITEM_ID), holdJson.getJsonObject(Constants.JSON_FIELD_ITEM));
           final Hold hold = getHold(holdJson, item);
           holds.add(hold);
         }
@@ -361,16 +338,18 @@ public class PatronServicesResourceImpl implements Patron {
   private Hold getHold(JsonObject holdJson, Item item) {
     return new Hold()
         .withItem(item)
-        .withExpirationDate(holdJson.getString(JSON_FIELD_REQUEST_EXPIRATION_DATE) == null ? null : new DateTime(holdJson.getString(JSON_FIELD_REQUEST_EXPIRATION_DATE), DateTimeZone.UTC).toDate())
+        .withExpirationDate(holdJson.getString(Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE) == null
+            ? null
+          : new DateTime(holdJson.getString(Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE), DateTimeZone.UTC).toDate())
         .withRequestId(holdJson.getString("id"))
-        .withPickupLocationId(holdJson.getString(JSON_FIELD_PICKUP_SERVICE_POINT_ID))
-        .withRequestDate(new DateTime(holdJson.getString(JSON_FIELD_REQUEST_DATE), DateTimeZone.UTC).toDate())
-        .withQueuePosition(holdJson.getInteger(JSON_FIELD_POSITION))
+        .withPickupLocationId(holdJson.getString(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID))
+        .withRequestDate(new DateTime(holdJson.getString(Constants.JSON_FIELD_REQUEST_DATE), DateTimeZone.UTC).toDate())
+        .withQueuePosition(holdJson.getInteger(Constants.JSON_FIELD_POSITION))
         .withStatus(Status.fromValue(holdJson.getString("status")));
   }
 
   private Account addCharges(Account account, JsonObject body, boolean includeCharges) {
-    final int totalCharges = body.getInteger(JSON_FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
+    final int totalCharges = body.getInteger(Constants.JSON_FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
     final List<Charge> charges = new ArrayList<>();
 
     account.setTotalChargesCount(totalCharges);
@@ -383,7 +362,7 @@ public class PatronServicesResourceImpl implements Patron {
       for (Object o : accountsJson) {
         if (o instanceof JsonObject) {
           final JsonObject accountJson = (JsonObject) o;
-          final Item item = new Item().withItemId(accountJson.getString(JSON_FIELD_ITEM_ID));
+          final Item item = new Item().withItemId(accountJson.getString(Constants.JSON_FIELD_ITEM_ID));
           final Charge charge = getCharge(accountJson, item);
           amount += charge.getChargeAmount().getAmount().doubleValue();
           if (includeCharges) {
@@ -405,28 +384,26 @@ public class PatronServicesResourceImpl implements Patron {
         .withItem(item)
         .withAccrualDate(new DateTime(chargeJson.getString("dateCreated"), DateTimeZone.UTC).toDate())
         .withChargeAmount(new TotalCharges().withAmount(chargeJson.getDouble("remaining")).withIsoCurrencyCode("USD"))
-        .withState(chargeJson.getJsonObject("paymentStatus", new JsonObject().put(JSON_FIELD_NAME,  "Unknown")).getString(JSON_FIELD_NAME))
+        .withState(chargeJson.getJsonObject("paymentStatus",
+            new JsonObject().put(Constants.JSON_FIELD_NAME,  "Unknown"))
+                  .getString(Constants.JSON_FIELD_NAME))
         .withReason(chargeJson.getString("feeFineType"));
   }
 
   private CompletableFuture<Account> lookupItem(HttpClientInterface httpClient, Charge charge, Account account, Map<String, String> okapiHeaders) {
     return getItem(charge, httpClient, okapiHeaders)
-        .thenApply(this::verifyAndExtractBody)
         .thenCompose(item ->getHoldingsRecord(item, httpClient, okapiHeaders))
-        .thenApply(this::verifyAndExtractBody)
+        .thenApply(LookupsUtils::verifyAndExtractBody)
         .thenCompose(holding -> getInstance(holding, httpClient, okapiHeaders))
-        .thenApply(this::verifyAndExtractBody)
+        .thenApply(LookupsUtils::verifyAndExtractBody)
         .thenApply(instance -> getItem(charge, instance))
         .thenApply(item -> updateItem(charge, item, account));
   }
 
-  private CompletableFuture<Response> getItem(Charge charge,
+  private CompletableFuture<JsonObject> getItem(Charge charge,
       HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
-    try {
-      return httpClient.request("/inventory/items/" + charge.getItem().getItemId(), okapiHeaders);
-    } catch (Exception e) {
-      throw new CompletionException(e);
-    }
+
+    return LookupsUtils.getItem(charge.getItem().getItemId(), okapiHeaders);
   }
 
   private CompletableFuture<Response> getHoldingsRecord(JsonObject item,
@@ -441,27 +418,19 @@ public class PatronServicesResourceImpl implements Patron {
   private CompletableFuture<Response> getInstance(JsonObject holdingsRecord,
       HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
     try {
-      return httpClient.request("/inventory/instances/" + holdingsRecord.getString(JSON_FIELD_INSTANCE_ID), okapiHeaders);
+      return httpClient.request("/inventory/instances/" + holdingsRecord.getString(Constants.JSON_FIELD_INSTANCE_ID), okapiHeaders);
     } catch (Exception e) {
       throw new CompletionException(e);
     }
   }
 
-  private JsonObject verifyAndExtractBody(Response response) {
-    if (!Response.isSuccess(response.getCode())) {
-      throw new CompletionException(new HttpException(response.getCode(),
-          response.getError().getString("errorMessage")));
-    }
-
-    return response.getBody();
-  }
 
   private Item getItem(Charge charge, JsonObject instance) {
     final String itemId = charge.getItem().getItemId();
     final JsonObject composite = new JsonObject()
-        .put(JSON_FIELD_CONTRIBUTORS, instance.getJsonArray(JSON_FIELD_CONTRIBUTORS))
-        .put(JSON_FIELD_INSTANCE_ID, instance.getString("id"))
-        .put(JSON_FIELD_TITLE, instance.getString(JSON_FIELD_TITLE));
+        .put(Constants.JSON_FIELD_CONTRIBUTORS, instance.getJsonArray(Constants.JSON_FIELD_CONTRIBUTORS))
+        .put(Constants.JSON_FIELD_INSTANCE_ID, instance.getString("id"))
+        .put(Constants.JSON_FIELD_TITLE, instance.getString(Constants.JSON_FIELD_TITLE));
 
     return getItem(itemId, composite);
   }

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -2,6 +2,7 @@ package org.folio.rest.impl;
 
 import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.Hold;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -18,43 +19,41 @@ class RequestObjectFactory {
     okapiHeaders = headers;
   }
 
-  CompletableFuture<JsonObject> createRequestByItem(String patronId, String itemId, Hold entity) {
-    return getRequestType(patronId, itemId)
+  CompletableFuture<JsonObject> createRequestByItem(String patronId, String itemId, Hold entity, HttpClientInterface httpClient) {
+    return getRequestType(patronId, itemId, httpClient)
       .thenApply(requestType -> {
-
         if (requestType != RequestType.NONE) {
+          final JsonObject holdJSON = new JsonObject()
+            .put(Constants.JSON_FIELD_ITEM_ID, itemId)
+            .put("requesterId", patronId)
+            .put("requestType", requestType.getValue())
+            .put(Constants.JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
+            .put("fulfilmentPreference", Constants.JSON_VALUE_HOLD_SHELF)
+            .put(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId());
 
-        final JsonObject holdJSON = new JsonObject()
-          .put(Constants.JSON_FIELD_ITEM_ID, itemId)
-          .put("requesterId", patronId)
-          .put("requestType", requestType.getValue())
-          .put(Constants.JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
-          .put("fulfilmentPreference", Constants.JSON_VALUE_HOLD_SHELF)
-          .put(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId());
-
-        if (entity.getExpirationDate() != null) {
-          holdJSON.put(Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE,
-            new DateTime(entity.getExpirationDate(), DateTimeZone.UTC).toString());
-        }
-        return holdJSON;
+          if (entity.getExpirationDate() != null) {
+            holdJSON.put(Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE,
+              new DateTime(entity.getExpirationDate(), DateTimeZone.UTC).toString());
+          }
+          return holdJSON;
         } else {
           return null;
         }
       });
   }
 
-  private CompletableFuture<RequestType> getRequestType(String patronId, String itemId) {
+  private CompletableFuture<RequestType> getRequestType(String patronId, String itemId, HttpClientInterface httpClient ) {
 
-    CompletableFuture<JsonObject> userFuture = LookupsUtils.getUser(patronId, okapiHeaders);
-    CompletableFuture<JsonObject> itemFuture = LookupsUtils.getItem(itemId, okapiHeaders);
+    CompletableFuture<JsonObject> userFuture = LookupsUtils.getUser(patronId, okapiHeaders, httpClient);
+    CompletableFuture<JsonObject> itemFuture = LookupsUtils.getItem(itemId, okapiHeaders, httpClient);
 
     RequestTypeParameters requestTypeParams = new RequestTypeParameters();
 
     return CompletableFuture.allOf(userFuture, itemFuture)
       .thenApply(x -> createRequestPolicyIdCriteria(itemFuture, userFuture, requestTypeParams))
-      .thenCompose(this::lookupRequestPolicyId)
+      .thenCompose((RequestTypeParameters criteria) -> lookupRequestPolicyId(criteria, httpClient))
       .thenCompose(policyIdResponse ->
-          LookupsUtils.getRequestPolicy(policyIdResponse.getString("requestPolicyId"), okapiHeaders))
+          LookupsUtils.getRequestPolicy(policyIdResponse.getString("requestPolicyId"), okapiHeaders, httpClient))
       .thenApply(RequestPolicy::from)
       .thenApply(requestPolicy -> getRequestType(requestPolicy, requestTypeParams.getItemStatus()));
   }
@@ -69,14 +68,14 @@ class RequestObjectFactory {
     return RequestType.NONE;
   }
 
-  private CompletableFuture<JsonObject> lookupRequestPolicyId(RequestTypeParameters criteria) {
+  private CompletableFuture<JsonObject> lookupRequestPolicyId(RequestTypeParameters criteria, HttpClientInterface httpClient) {
     String queryString = String.format(
       "item_type_id=%s&loan_type_id=%s&patron_type_id=%s&shelving_location_id=%s",
       criteria.getItemMaterialTypeId(), criteria.getItemLoanTypeId(),
       criteria.getPatronGroupId(), criteria.getItemLocationId()
     );
 
-    return LookupsUtils.getRequestPolicyId(queryString, okapiHeaders);
+    return LookupsUtils.getRequestPolicyId(queryString, okapiHeaders, httpClient);
   }
 
   private RequestTypeParameters createRequestPolicyIdCriteria(CompletableFuture<JsonObject> itemFuture,

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -1,0 +1,102 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.rest.jaxrs.model.Hold;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.rest.impl.Constants.*;
+
+class RequestObjectFactory {
+  private final Map<String, String> okapiHeaders;
+
+  RequestObjectFactory(Map<String, String> headers) {
+    okapiHeaders = headers;
+  }
+
+  CompletableFuture<JsonObject> createRequestByItem(String patronId, String itemId, Hold entity) {
+    return getRequestType(patronId, itemId)
+      .thenApply(requestType -> {
+
+        if (requestType != RequestType.NONE) {
+
+        final JsonObject holdJSON = new JsonObject()
+          .put(Constants.JSON_FIELD_ITEM_ID, itemId)
+          .put("requesterId", patronId)
+          .put("requestType", requestType.getValue())
+          .put(Constants.JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
+          .put("fulfilmentPreference", Constants.JSON_VALUE_HOLD_SHELF)
+          .put(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId());
+
+        if (entity.getExpirationDate() != null) {
+          holdJSON.put(Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE,
+            new DateTime(entity.getExpirationDate(), DateTimeZone.UTC).toString());
+        }
+        return holdJSON;
+        } else {
+          return null;
+        }
+      });
+  }
+
+  private CompletableFuture<RequestType> getRequestType(String patronId, String itemId) {
+
+    CompletableFuture<JsonObject> userFuture = LookupsUtils.getUser(patronId, okapiHeaders);
+    CompletableFuture<JsonObject> itemFuture = LookupsUtils.getItem(itemId, okapiHeaders);
+
+    RequestTypeParameters requestTypeParams = new RequestTypeParameters();
+
+    return CompletableFuture.allOf(userFuture, itemFuture)
+      .thenApply(x -> createRequestPolicyIdCriteria(itemFuture, userFuture, requestTypeParams))
+      .thenCompose(this::lookupRequestPolicyId)
+      .thenCompose(policyIdResponse ->
+          LookupsUtils.getRequestPolicy(policyIdResponse.getString("requestPolicyId"), okapiHeaders))
+      .thenApply(RequestPolicy::from)
+      .thenApply(requestPolicy -> getRequestType(requestPolicy, requestTypeParams.getItemStatus()));
+  }
+
+  private RequestType getRequestType(RequestPolicy policy,  ItemStatus itemStatus) {
+    List<RequestType> allowableRequestTypes = policy.getRequestTypes();
+    for (RequestType aRequestType : allowableRequestTypes) {
+      if (RequestTypeItemStatusWhiteList.canCreateRequestForItem(itemStatus, aRequestType)){
+        return aRequestType;
+      }
+    }
+    return RequestType.NONE;
+  }
+
+  private CompletableFuture<JsonObject> lookupRequestPolicyId(RequestTypeParameters criteria) {
+    String queryString = String.format(
+      "item_type_id=%s&loan_type_id=%s&patron_type_id=%s&shelving_location_id=%s",
+      criteria.getItemMaterialTypeId(), criteria.getItemLoanTypeId(),
+      criteria.getPatronGroupId(), criteria.getItemLocationId()
+    );
+
+    return LookupsUtils.getRequestPolicyId(queryString, okapiHeaders);
+  }
+
+  private RequestTypeParameters createRequestPolicyIdCriteria(CompletableFuture<JsonObject> itemFuture,
+                                                              CompletableFuture<JsonObject> userFuture,
+                                                              RequestTypeParameters requestTypeParams) {
+    JsonObject itemJson = itemFuture.join();
+    requestTypeParams.setItemMaterialTypeId(getJsonObjectProperty(itemJson, "materialType", JSON_FIELD_ID));
+    requestTypeParams.setItemLoanTypeId(getJsonObjectProperty(itemJson, "permanentLoanType", JSON_FIELD_ID));
+    requestTypeParams.setItemLocationId(getJsonObjectProperty(itemJson, "effectiveLocation", JSON_FIELD_ID));
+    requestTypeParams.setPatronGroupId(userFuture.join().getString(JSON_FIELD_PATRON_GROUP));
+    requestTypeParams.setItemStatus(ItemStatus.from(getJsonObjectProperty(itemJson, "status", JSON_FIELD_NAME)));
+
+    return requestTypeParams;
+  }
+
+  private String getJsonObjectProperty(JsonObject jsonObject, String objectName, String propertyName) {
+    JsonObject destinedObject = jsonObject.getJsonObject(objectName);
+    if (destinedObject != null) {
+      return destinedObject.getString(propertyName);
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/folio/rest/impl/RequestPolicy.java
+++ b/src/main/java/org/folio/rest/impl/RequestPolicy.java
@@ -34,7 +34,7 @@ class RequestPolicy {
 
     String arrayPropertyName = "requestTypes";
 
-    if(within == null || !within.containsKey(arrayPropertyName)) {
+    if (within == null || !within.containsKey(arrayPropertyName)) {
       return Stream.empty();
     }
 
@@ -51,10 +51,9 @@ class RequestPolicy {
 
   private static Function<Object, String> castToString() {
     return entry -> {
-      if(entry instanceof String) {
-        return (String)entry;
-      }
-      else {
+      if (entry instanceof String) {
+        return (String) entry;
+      } else {
         return null;
       }
     };

--- a/src/main/java/org/folio/rest/impl/RequestPolicy.java
+++ b/src/main/java/org/folio/rest/impl/RequestPolicy.java
@@ -1,0 +1,62 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class RequestPolicy {
+  private final List<String> requestTypes;
+
+  private RequestPolicy(List<String> requestTypes) {
+    this.requestTypes = requestTypes;
+  }
+
+  static RequestPolicy from(JsonObject representation) {
+    return new RequestPolicy(RequestPolicy
+      .toStream(representation)
+      .collect(Collectors.toList()));
+  }
+
+  List<RequestType> getRequestTypes() {
+    return requestTypes
+      .stream()
+      .map(RequestType::from)
+      .collect(Collectors.toList());
+  }
+
+  private static Stream<String> toStream(
+    JsonObject within) {
+
+    String arrayPropertyName = "requestTypes";
+
+    if(within == null || !within.containsKey(arrayPropertyName)) {
+      return Stream.empty();
+    }
+
+    return toStream(within.getJsonArray(arrayPropertyName));
+  }
+
+  private static Stream<String> toStream(JsonArray array) {
+    return array
+      .stream()
+      .filter(Objects::nonNull)
+      .map(castToString())
+      .filter(Objects::nonNull);
+  }
+
+  private static Function<Object, String> castToString() {
+    return entry -> {
+      if(entry instanceof String) {
+        return (String)entry;
+      }
+      else {
+        return null;
+      }
+    };
+  }
+}

--- a/src/main/java/org/folio/rest/impl/RequestType.java
+++ b/src/main/java/org/folio/rest/impl/RequestType.java
@@ -2,8 +2,6 @@ package org.folio.rest.impl;
 
 import java.util.Arrays;
 
-import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
-
 public enum RequestType {
   NONE(""),
   HOLD("Hold"),

--- a/src/main/java/org/folio/rest/impl/RequestType.java
+++ b/src/main/java/org/folio/rest/impl/RequestType.java
@@ -1,0 +1,33 @@
+package org.folio.rest.impl;
+
+import java.util.Arrays;
+
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+
+public enum RequestType {
+  NONE(""),
+  HOLD("Hold"),
+  RECALL("Recall"),
+  PAGE("Page");
+
+  public final String value;
+
+  public static RequestType from(String value) {
+    return Arrays.stream(values())
+      .filter(status -> status.nameMatches(value))
+      .findFirst()
+      .orElse(NONE);
+  }
+
+  RequestType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public boolean nameMatches(String value) {
+    return equalsIgnoreCase(getValue(), value);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/RequestType.java
+++ b/src/main/java/org/folio/rest/impl/RequestType.java
@@ -28,6 +28,6 @@ public enum RequestType {
   }
 
   public boolean nameMatches(String value) {
-    return equalsIgnoreCase(getValue(), value);
+    return this.value.equalsIgnoreCase(value);
   }
 }

--- a/src/main/java/org/folio/rest/impl/RequestTypeItemStatusWhiteList.java
+++ b/src/main/java/org/folio/rest/impl/RequestTypeItemStatusWhiteList.java
@@ -1,0 +1,88 @@
+package org.folio.rest.impl;
+
+import java.util.EnumMap;
+
+class RequestTypeItemStatusWhiteList {
+
+  private static EnumMap<ItemStatus, Boolean> recallRules;
+  private static EnumMap<ItemStatus, Boolean> holdRules;
+  private static EnumMap<ItemStatus, Boolean> pageRules;
+  private static EnumMap<ItemStatus, Boolean> noneRules;
+  private static EnumMap<RequestType, EnumMap<ItemStatus, Boolean>> requestsRulesMap;
+
+  static {
+    initRecallRules();
+    initHoldRules();
+    initPageRules();
+    initNoneRules();
+    initRequestRulesMap();
+  }
+
+  private RequestTypeItemStatusWhiteList() {
+    throw new IllegalStateException();
+  }
+
+  private static void initRecallRules() {
+    recallRules = new EnumMap<>(ItemStatus.class);
+    recallRules.put(ItemStatus.CHECKED_OUT, true);
+    recallRules.put(ItemStatus.AVAILABLE, false);
+    recallRules.put(ItemStatus.AWAITING_PICKUP, true);
+    recallRules.put(ItemStatus.IN_TRANSIT, true);
+    recallRules.put(ItemStatus.MISSING, false);
+    recallRules.put(ItemStatus.PAGED, true);
+    recallRules.put(ItemStatus.ON_ORDER, true);
+    recallRules.put(ItemStatus.IN_PROCESS, true);
+    recallRules.put(ItemStatus.NONE, false);
+  }
+
+  private static void initHoldRules() {
+    holdRules = new EnumMap<>(ItemStatus.class);
+    holdRules.put(ItemStatus.CHECKED_OUT, true);
+    holdRules.put(ItemStatus.AVAILABLE, false);
+    holdRules.put(ItemStatus.AWAITING_PICKUP, true);
+    holdRules.put(ItemStatus.IN_TRANSIT, true);
+    holdRules.put(ItemStatus.MISSING, true);
+    holdRules.put(ItemStatus.PAGED, true);
+    holdRules.put(ItemStatus.ON_ORDER, true);
+    holdRules.put(ItemStatus.IN_PROCESS, true);
+    holdRules.put(ItemStatus.NONE, true);
+  }
+
+  private static void initPageRules() {
+    pageRules = new EnumMap<>(ItemStatus.class);
+    pageRules.put(ItemStatus.CHECKED_OUT, false);
+    pageRules.put(ItemStatus.AVAILABLE, true);
+    pageRules.put(ItemStatus.AWAITING_PICKUP, false);
+    pageRules.put(ItemStatus.IN_TRANSIT, false);
+    pageRules.put(ItemStatus.MISSING, false);
+    pageRules.put(ItemStatus.PAGED, false);
+    pageRules.put(ItemStatus.ON_ORDER, false);
+    pageRules.put(ItemStatus.IN_PROCESS, false);
+    pageRules.put(ItemStatus.NONE, false);
+  }
+
+  private static void initNoneRules() {
+    noneRules = new EnumMap<>(ItemStatus.class);
+    noneRules.put(ItemStatus.CHECKED_OUT, false);
+    noneRules.put(ItemStatus.AVAILABLE, false);
+    noneRules.put(ItemStatus.AWAITING_PICKUP, false);
+    noneRules.put(ItemStatus.IN_TRANSIT, false);
+    noneRules.put(ItemStatus.MISSING, false);
+    noneRules.put(ItemStatus.PAGED, false);
+    noneRules.put(ItemStatus.ON_ORDER, false);
+    noneRules.put(ItemStatus.IN_PROCESS, false);
+    noneRules.put(ItemStatus.NONE, false);
+  }
+
+  private static void initRequestRulesMap() {
+    requestsRulesMap = new EnumMap<>(RequestType.class);
+    requestsRulesMap.put(RequestType.HOLD, holdRules);
+    requestsRulesMap.put(RequestType.PAGE, pageRules);
+    requestsRulesMap.put(RequestType.RECALL, recallRules);
+    requestsRulesMap.put(RequestType.NONE, noneRules);
+  }
+
+  public static boolean canCreateRequestForItem(ItemStatus itemStatus, RequestType requestType) {
+    return requestsRulesMap.get(requestType).get(itemStatus);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/RequestTypeParameters.java
+++ b/src/main/java/org/folio/rest/impl/RequestTypeParameters.java
@@ -1,0 +1,50 @@
+package org.folio.rest.impl;
+
+class RequestTypeParameters {
+
+  private String itemMaterialTypeId;
+  private String itemPatronGroupId;
+  private String itemLoanTypeId;
+  private String itemLocationId;
+  private ItemStatus itemStatus;
+
+  String getItemMaterialTypeId() {
+    return itemMaterialTypeId;
+  }
+
+  void setItemMaterialTypeId(String materialTypeId) {
+    this.itemMaterialTypeId = materialTypeId;
+  }
+
+  String getPatronGroupId() {
+    return itemPatronGroupId;
+  }
+
+  void setPatronGroupId(String patronGroupId) {
+    this.itemPatronGroupId = patronGroupId;
+  }
+
+  String getItemLoanTypeId() {
+    return itemLoanTypeId;
+  }
+
+  void setItemLoanTypeId(String loanTypeId) {
+    this.itemLoanTypeId = loanTypeId;
+  }
+
+  String getItemLocationId() {
+    return itemLocationId;
+  }
+
+  void setItemLocationId(String locationId) {
+    this.itemLocationId = locationId;
+  }
+
+  void setItemStatus(ItemStatus itemStatus) {
+    this.itemStatus = itemStatus;
+  }
+
+  ItemStatus getItemStatus() {
+    return this.itemStatus;
+  }
+}

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -98,6 +98,18 @@ public class PatronResourceImplTest {
   private final String feeFineOverdueId = "cdf3970f-7ed2-4dae-8ae3-a8250a83a9a0";
   private final String feeFineDamageBookId = "881c628b-e1c4-4711-b9d7-090af40f6a8f";
   private final String feeFineDamageEquipmentId = "ca295e87-223f-403c-9eee-a152c47bf67f";
+  private final String requestPolicyIdAll = "e4c3b92c-ddb6-4006-a0fd-20fab52b95b9";
+  private final String requestPolicyIdHold = "e4c3b92c-ddb6-4006-a0fd-20fab52b95c9";
+  private final String requestPolicyIdPage = "e4c3b92c-ddb6-4006-a0fd-20fab52b95d9";
+  private final String materialTypeId1 = "1a54b431-2e4f-452d-9cae-9cee66c9a892";
+  private final String materialTypeId2 = "1a54b431-2e4f-452d-9cae-9cee66c99992";
+  private final String materialTypeId3 = "1a54b431-2e4f-452d-9cae-9cee66c99999";
+  private final String loanTypeId1 = "2b94c631-fca9-4892-a730-03ee529ffe27";
+  private final String patronGroupId1 = "3684a786-6671-4268-8ed0-9db82ebca60b";
+  private final String effectiveLocation1 = "fcd64ce1-6995-48f0-840e-89ffa2288371";
+  private final String availableItemId = "32e5757d-6566-466e-b69d-994eb33d2b62";
+  private final String checkedoutItemId = "32e5757d-6566-466e-b69d-994eb33d2b73";
+  private final String intransitItemId = "32e5757d-6566-466e-b69d-994eb33d2c98";
 
   static {
     System.setProperty("vertx.logger-delegate-factory-class-name",
@@ -176,22 +188,29 @@ public class PatronResourceImplTest {
             req.response()
               .setStatusCode(201)
               .putHeader("content-type", "application/json")
-              .end(readMockFile(mockDataFolder + "/holds_create.json"));
+              .end(readMockFile(mockDataFolder + "/page_create.json"));
           }
-        } else {
-          if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20status%%3D%%3DOpen%%2A%%29", Integer.MAX_VALUE, goodUserId))) {
-            req.response()
-              .setStatusCode(200)
-              .putHeader("content-type", "application/json")
-              .end(readMockFile(mockDataFolder + "/holds_all.json"));
-          } else if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20status%%3D%%3DOpen%%2A%%29", 1, goodUserId))) {
-            req.response()
-              .setStatusCode(200)
-              .putHeader("content-type", "application/json")
-              .end(readMockFile(mockDataFolder + "/holds_totals.json"));
+        } else if (req.path().equals("/circulation/requests/")) {
+            if (req.method() == HttpMethod.POST) {
+                req.response()
+                  .setStatusCode(201)
+                  .putHeader("content-type", "application/json")
+                  .end(readMockFile(mockDataFolder + "/holds_create.json"));
+            }
           } else {
-            req.response().setStatusCode(500).end("Unexpected call: " + req.path());
-          }
+            if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20status%%3D%%3DOpen%%2A%%29", Integer.MAX_VALUE, goodUserId))) {
+              req.response()
+                .setStatusCode(200)
+                .putHeader("content-type", "application/json")
+                .end(readMockFile(mockDataFolder + "/holds_all.json"));
+            } else if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20status%%3D%%3DOpen%%2A%%29", 1, goodUserId))) {
+              req.response()
+                .setStatusCode(200)
+                .putHeader("content-type", "application/json")
+                .end(readMockFile(mockDataFolder + "/holds_totals.json"));
+            } else {
+              req.response().setStatusCode(500).end("Unexpected call: " + req.path());
+            }
         }
       } else if (req.path().equals("/circulation/requests/instances")) {
         if (req.method() == HttpMethod.POST) {
@@ -332,6 +351,21 @@ public class PatronResourceImplTest {
           .setStatusCode(200)
           .putHeader("content-type", "application/json")
           .end(readMockFile(mockDataFolder + "/item_book3.json"));
+      } else if (req.path().equals("/inventory/items/" + goodItemId)) {
+        req.response()
+          .setStatusCode(200)
+          .putHeader("content-type", "application/json")
+          .end(readMockFile(mockDataFolder + "/item_book4.json"));
+      } else if (req.path().equals("/inventory/items/" + checkedoutItemId)) {
+        req.response()
+          .setStatusCode(200)
+          .putHeader("content-type", "application/json")
+          .end(readMockFile(mockDataFolder + "/item_checkedout.json"));
+      }  else if (req.path().equals("/inventory/items/" + intransitItemId)) {
+        req.response()
+          .setStatusCode(200)
+          .putHeader("content-type", "application/json")
+          .end(readMockFile(mockDataFolder + "/item_intransit.json"));
       } else if (req.path().equals("/inventory/items/" + itemCameraId)) {
         req.response()
           .setStatusCode(200)
@@ -411,11 +445,45 @@ public class PatronResourceImplTest {
             .putHeader("content-type", "application/json")
             .end(readMockFile(mockDataFolder + "/renew_create.json"));
         }
+      } else if (req.path().equals("/circulation/rules/request-policy")) {
+          if (req.query().equals(String.format("item_type_id=%s&loan_type_id=%s&patron_type_id=%s&shelving_location_id=%s",
+                                                materialTypeId1, loanTypeId1, patronGroupId1, effectiveLocation1))) {
+            req.response()
+              .setStatusCode(200)
+              .putHeader("content-type", "application/json")
+              .end(readMockFile(mockDataFolder + "/requestPolicyId_all.json"));
+          } else if (req.query().equals(String.format("item_type_id=%s&loan_type_id=%s&patron_type_id=%s&shelving_location_id=%s",
+            materialTypeId2, loanTypeId1, patronGroupId1, effectiveLocation1))) {
+            req.response()
+              .setStatusCode(200)
+              .putHeader("content-type", "application/json")
+              .end(readMockFile(mockDataFolder + "/requestPolicyId_hold.json"));
+          } else if (req.query().equals(String.format("item_type_id=%s&loan_type_id=%s&patron_type_id=%s&shelving_location_id=%s",
+            materialTypeId3, loanTypeId1, patronGroupId1, effectiveLocation1))) {
+            req.response()
+              .setStatusCode(200)
+              .putHeader("content-type", "application/json")
+              .end(readMockFile(mockDataFolder + "/requestPolicyId_page.json"));
+          }
+      } else if (req.path().contains("/request-policy-storage/request-policies/" + requestPolicyIdAll)) {
+        req.response()
+          .setStatusCode(200)
+          .putHeader("content-type", "application/json")
+          .end(readMockFile(mockDataFolder + "/requestPolicy_all.json"));
+      } else if (req.path().contains("/request-policy-storage/request-policies/" + requestPolicyIdHold)) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile(mockDataFolder + "/requestPolicy_hold.json"));
+      } else if (req.path().contains("/request-policy-storage/request-policies/" + requestPolicyIdPage)) {
+        req.response()
+          .setStatusCode(200)
+          .putHeader("content-type", "application/json")
+          .end(readMockFile(mockDataFolder + "/requestPolicy_page.json"));
       } else {
         req.response().setStatusCode(500).end("Unexpected call: " + req.path());
       }
     });
-
     server.listen(serverPort, host, context.succeeding(id -> mockOkapiStarted.flag()));
   }
 
@@ -702,7 +770,7 @@ public class PatronResourceImplTest {
         .header(contentTypeHeader)
         .body(readMockFile(mockDataFolder + "/request_testPostPatronAccountByIdItemByItemIdHold.json"))
         .pathParam("accountId", goodUserId)
-        .pathParam("itemId", goodItemId)
+        .pathParam("itemId", checkedoutItemId)
       .when()
         .post(accountPath + itemPath + holdPath)
       .then()
@@ -716,6 +784,66 @@ public class PatronResourceImplTest {
     final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHold.json"));
 
     verifyHold(expectedJson, json);
+
+    // Test done
+    logger.info("Test done");
+  }
+
+  @Test
+  public final void testPostPatronAccountByIdItemByItemIdPage() {
+    logger.info("Testing creating a page request on an item for the specified user");
+
+    final Response r = given()
+      .log().all()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .body(readMockFile(mockDataFolder + "/request_testPostPatronAccountByIdItemByItemIdHold.json"))
+      .pathParam("accountId", goodUserId)
+      .pathParam("itemId", availableItemId)
+      .when()
+      .post(accountPath + itemPath + holdPath)
+      .then()
+      .log().all()
+      .contentType(ContentType.JSON)
+      .statusCode(201)
+      .extract().response();
+
+    final String body = r.getBody().asString();
+    final JsonObject json = new JsonObject(body);
+    final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHold.json"));
+
+    verifyHold(expectedJson, json);
+
+    // Test done
+    logger.info("Test done");
+  }
+
+  /*
+  This test checks the negative case of not being able to place a request due to request policy and whitelist restrictions
+   */
+  @Test
+  public final void testCannotPostPatronAccountByIdItemByItemIdRequest() {
+    logger.info("Testing creating a page request on an item for the specified user");
+
+    final Response r = given()
+      .log().all()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .body(readMockFile(mockDataFolder + "/request_testPostPatronAccountByIdItemByItemIdHold.json"))
+      .pathParam("accountId", goodUserId)
+      .pathParam("itemId", intransitItemId)
+      .when()
+      .post(accountPath + itemPath + holdPath)
+      .then()
+      .log().all()
+      .contentType(TEXT)
+      .statusCode(500)
+      .extract().response();
+
+    final String body = r.getBody().asString();
+    assertEquals("Cannot find a valid request type for this item", body);
 
     // Test done
     logger.info("Test done");

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -831,7 +831,7 @@ public class PatronResourceImplTest {
     assertNotNull(errors.getErrors());
     assertEquals(1, errors.getErrors().size());
     assertEquals(expectedMessage, errors.getErrors().get(0).getMessage());
-    /////
+
     assertNotNull(errors.getErrors().get(0).getParameters());
     assertEquals(1, errors.getErrors().get(0).getParameters().size());
     assertEquals("itemId", errors.getErrors().get(0).getParameters().get(0).getKey());
@@ -1081,8 +1081,6 @@ public class PatronResourceImplTest {
 
   static Stream<Arguments> itemRequestsParams() {
     return Stream.of(
-      // Even though we receive a 400, we need to return a 500 since there is nothing the client
-      // can do to correct the 400. We'd have to correct it in the code.
       Arguments.of(availableItemId, "/response_testPostPatronAccountByIdItemByItemIdPage.json" ),
       Arguments.of(checkedoutItemId, "/response_testPostPatronAccountByIdItemByItemIdHold.json")
     );

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -819,12 +819,23 @@ public class PatronResourceImplTest {
       .post(accountPath + itemPath + holdPath)
       .then()
       .log().all()
-      .contentType(TEXT)
-      .statusCode(500)
+      .contentType(ContentType.JSON)
+      .statusCode(422)
       .extract().response();
 
     final String body = r.getBody().asString();
-    assertEquals("Cannot find a valid request type for this item", body);
+    final Errors errors = Json.decodeValue(body, Errors.class);
+
+    final String expectedMessage = "Cannot find a valid request type for this item";
+    assertNotNull(errors);
+    assertNotNull(errors.getErrors());
+    assertEquals(1, errors.getErrors().size());
+    assertEquals(expectedMessage, errors.getErrors().get(0).getMessage());
+    /////
+    assertNotNull(errors.getErrors().get(0).getParameters());
+    assertEquals(1, errors.getErrors().get(0).getParameters().size());
+    assertEquals("itemId", errors.getErrors().get(0).getParameters().get(0).getKey());
+    assertEquals(intransitItemId, errors.getErrors().get(0).getParameters().get(0).getValue());
 
     // Test done
     logger.info("Test done");

--- a/src/test/java/org/folio/rest/impl/RequestTypeItemStatusWhiteListTests.java
+++ b/src/test/java/org/folio/rest/impl/RequestTypeItemStatusWhiteListTests.java
@@ -1,0 +1,70 @@
+package org.folio.rest.impl;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+public class RequestTypeItemStatusWhiteListTests {
+
+  @Test
+  public void canCreateHoldRequestWhenItemStatusCheckedOut() {
+    assertTrue(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.CHECKED_OUT, RequestType.HOLD));
+  }
+
+  @Test
+  public void canCreateRecallRequestWhenItemStatusCheckedOut() {
+    assertTrue(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.CHECKED_OUT, RequestType.RECALL));
+  }
+
+  @Test
+  public void cannotCreatePagedRequestWhenItemStatusCheckedOut() {
+    assertFalse(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.CHECKED_OUT, RequestType.PAGE));
+  }
+
+  @Test
+  public void cannotCreateNoneRequestWhenItemStatusIsAnything() {
+    assertFalse(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.CHECKED_OUT, RequestType.NONE));
+  }
+
+  @Test
+  public void canCreateHoldRequestWhenItemStatusOnOrder() {
+    assertTrue(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.ON_ORDER, RequestType.HOLD));
+  }
+
+  @Test
+  public void canCreateRecallRequestWhenItemStatusOnOrder() {
+    assertTrue(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.ON_ORDER, RequestType.RECALL));
+  }
+
+  @Test
+  public void cannotCreatePagedRequestWhenItemStatusOnOrder() {
+    assertFalse(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.ON_ORDER, RequestType.PAGE));
+  }
+
+
+  @Test
+  public void canCreateHoldRequestWhenItemStatusInProcess() {
+    assertTrue(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.IN_PROCESS, RequestType.HOLD));
+  }
+
+  @Test
+  public void canCreateRecallRequestWhenItemStatusInProcess() {
+    assertTrue(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.IN_PROCESS, RequestType.RECALL));
+  }
+
+  @Test
+  public void cannotCreatePagedRequestWhenItemStatusInProcess() {
+    assertFalse(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.IN_PROCESS, RequestType.PAGE));
+  }
+
+  @Test
+  public void canCreateRecallRequestWhenItemStatusPaged() {
+    assertTrue(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.PAGED, RequestType.RECALL));
+  }
+
+  @Test
+  public void cannotCreatePagedRequestWhenItemStatusIsNone() {
+    assertFalse(RequestTypeItemStatusWhiteList.canCreateRequestForItem(ItemStatus.NONE, RequestType.PAGE));
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/holds_create.json
+++ b/src/test/resources/PatronServicesResourceImpl/holds_create.json
@@ -1,7 +1,7 @@
 {
   "id": "dd238b5b-01fc-4205-83b8-ce27a650d827",
   "requesterId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
-  "itemId": "32e5757d-6566-466e-b69d-994eb33d2b62",
+  "itemId": "32e5757d-6566-466e-b69d-994eb33d2b73",
   "requestType": "Hold",
   "requestDate": "2018-05-30T08:01:30Z",
   "requestExpirationDate": "3000-01-30T08:16:30Z",

--- a/src/test/resources/PatronServicesResourceImpl/item_book4.json
+++ b/src/test/resources/PatronServicesResourceImpl/item_book4.json
@@ -1,0 +1,17 @@
+{
+  "status": {
+    "name": "Available"
+  },
+  "materialType": {
+    "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+    "name": "book"
+  },
+  "permanentLoanType": {
+    "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+    "name": "Can circulate"
+  },
+  "effectiveLocation": {
+    "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+    "name": "Main Library"
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/item_checkedout.json
+++ b/src/test/resources/PatronServicesResourceImpl/item_checkedout.json
@@ -1,0 +1,17 @@
+{
+  "status": {
+    "name": "Checked out"
+  },
+  "materialType": {
+    "id": "1a54b431-2e4f-452d-9cae-9cee66c99992",
+    "name": "book"
+  },
+  "permanentLoanType": {
+    "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+    "name": "Can circulate"
+  },
+  "effectiveLocation": {
+    "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+    "name": "Main Library"
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/item_intransit.json
+++ b/src/test/resources/PatronServicesResourceImpl/item_intransit.json
@@ -1,0 +1,17 @@
+{
+  "status": {
+    "name": "In transit"
+  },
+  "materialType": {
+    "id": "1a54b431-2e4f-452d-9cae-9cee66c99999",
+    "name": "book"
+  },
+  "permanentLoanType": {
+    "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+    "name": "Can circulate"
+  },
+  "effectiveLocation": {
+    "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+    "name": "Main Library"
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/page_create.json
+++ b/src/test/resources/PatronServicesResourceImpl/page_create.json
@@ -1,0 +1,21 @@
+{
+  "id": "dd238b5b-01fc-4205-83b8-ce27a650d827",
+  "requesterId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+  "itemId": "32e5757d-6566-466e-b69d-994eb33d2b62",
+  "requestType": "Page",
+  "requestDate": "2018-05-30T08:01:30Z",
+  "requestExpirationDate": "3000-01-30T08:16:30Z",
+  "fulfilmentPreference": "Hold Shelf",
+  "status": "Open - Not yet filled",
+  "position": 1,
+  "item" :{
+    "title": "Something's Got a Hold on Me",
+    "instanceId": "23611f0b-35cc-4f40-af09-75907d7cc421",
+    "contributors": [
+      {"name": "Etta James"},
+      {"name": "Leroy Kirkland"},
+      {"name": "Pearl Woods"}
+    ]
+  },
+  "pickupServicePointId": "963396d7-c96f-4bb1-a24c-42e868a8823d"
+}

--- a/src/test/resources/PatronServicesResourceImpl/requestPolicyId_all.json
+++ b/src/test/resources/PatronServicesResourceImpl/requestPolicyId_all.json
@@ -1,0 +1,3 @@
+{
+  "requestPolicyId" : "e4c3b92c-ddb6-4006-a0fd-20fab52b95b9"
+}

--- a/src/test/resources/PatronServicesResourceImpl/requestPolicyId_hold.json
+++ b/src/test/resources/PatronServicesResourceImpl/requestPolicyId_hold.json
@@ -1,0 +1,3 @@
+{
+  "requestPolicyId" : "e4c3b92c-ddb6-4006-a0fd-20fab52b95c9"
+}

--- a/src/test/resources/PatronServicesResourceImpl/requestPolicyId_page.json
+++ b/src/test/resources/PatronServicesResourceImpl/requestPolicyId_page.json
@@ -1,0 +1,3 @@
+{
+  "requestPolicyId" : "e4c3b92c-ddb6-4006-a0fd-20fab52b95d9"
+}

--- a/src/test/resources/PatronServicesResourceImpl/requestPolicy_all.json
+++ b/src/test/resources/PatronServicesResourceImpl/requestPolicy_all.json
@@ -1,0 +1,10 @@
+{
+  "id": "e4c3b92c-ddb6-4006-a0fd-20fab52b95b9",
+  "name": "Example Request Policy",
+  "description": "An example request policy",
+  "requestTypes": [
+    "Hold",
+    "Page",
+    "Recall"
+  ]
+}

--- a/src/test/resources/PatronServicesResourceImpl/requestPolicy_hold.json
+++ b/src/test/resources/PatronServicesResourceImpl/requestPolicy_hold.json
@@ -1,0 +1,8 @@
+{
+  "id": "e4c3b92c-ddb6-4006-a0fd-20fab52b95c9",
+  "name": "Example Request Policy",
+  "description": "An example request policy",
+  "requestTypes": [
+    "Hold"
+  ]
+}

--- a/src/test/resources/PatronServicesResourceImpl/requestPolicy_page.json
+++ b/src/test/resources/PatronServicesResourceImpl/requestPolicy_page.json
@@ -1,0 +1,8 @@
+{
+  "id": "e4c3b92c-ddb6-4006-a0fd-20fab52b95d9",
+  "name": "Example Request Policy",
+  "description": "An example request policy",
+  "requestTypes": [
+    "Page"
+  ]
+}

--- a/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdItemByItemIdPage.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdItemByItemIdPage.json
@@ -2,7 +2,7 @@
     "requestId": "dd238b5b-01fc-4205-83b8-ce27a650d827",
     "item": {
         "instanceId": "23611f0b-35cc-4f40-af09-75907d7cc421",
-        "itemId": "32e5757d-6566-466e-b69d-994eb33d2b73",
+        "itemId": "32e5757d-6566-466e-b69d-994eb33d2b62",
         "title": "Something's Got a Hold on Me",
         "author": "Etta James; Leroy Kirkland; Pearl Woods"
     },

--- a/src/test/resources/PatronServicesResourceImpl/user_active.json
+++ b/src/test/resources/PatronServicesResourceImpl/user_active.json
@@ -1,1 +1,5 @@
-{"id":"1ec54964-70f0-44cc-bd19-2a892ea0d336","active":true}
+{
+  "id":"1ec54964-70f0-44cc-bd19-2a892ea0d336",
+  "active":true,
+  "patronGroup": "3684a786-6671-4268-8ed0-9db82ebca60b"
+}


### PR DESCRIPTION
- Implemented the logic to determine request type based on a tenant's request policy and white list.

- Borrowed code for white list, requestType, itemStatus, request policy from mod-circulation.

-  Essentially, it gets a list of allowed request types from the request policy, and checks the types with the item status against the white list.  When it finds a first allowable request type and item status combination, it will use that request type.  When it cannot find an appropriate request type to make a request, it returns an error with the message "Cannot find a valid request type for this item".

Refactored the code as follows:
- Created a new RequestObjectFactory class that handles creating item-level request objects.  In the future we could migrate instance-level object requests creation into here as well. 
- Created a constant class to hold constants for the entire project to refer to.
- Created a LookupsUtil class that call Okapi to look up mainly request policies and user and item. We could move other FOLIO lookups from the main PatronResourceImpl.java into this class as well, but that's for future. This class now has the method to verify the response for reusability and getHttpClient (OkapiClient) across the project. I dont' think calling HttpClientFactory.getHttpClient(okapiURL, tenantId) over and over from this class would pose any problem, but please pay close attention to it. 
