### PR TITLE
MODPATRON-54 Update circulation interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -65,7 +65,7 @@
     },
     {
       "id": "circulation",
-      "version": "9.5 10.0"
+      "version": "9.5 10.0 11.0"
     },
     {
       "id": "feesfines",


### PR DESCRIPTION
Resolves [MODPATRON-54](https://issues.folio.org/browse/MODPATRON-54).

### Purpose
There is a breaking change in `mod-circulaion` that will be merge soon. Modules that have a dependency on `circulation` interface need to be updated to support version `11.0`.

### Warning
There are multiple PRs with `circulation` interface version update, they all should be merged on the same day. 
**DO NOT MERGE** this PR until then.