### PR TITLE
MODPATRON-59: Account lookup fails if patron has fees/fines without item info

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 4.5.0 (IN PROGRESS)
 
  * [MODPATRON-52](https://issues.folio.org/browse/MODPATRON-52): Requires `circulation 9.5 10`
+ * Accounts without item data attached no longer result in errors when using "includeCharges" flag (MODPATRON-59)
 
 ## 4.4.0 2021-03-15
 

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
 
 import org.folio.patron.rest.exceptions.HttpException;
 import org.folio.patron.rest.exceptions.ModuleGeneratedHttpException;
@@ -36,13 +35,10 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import static org.folio.rest.impl.HoldHelpers.*;
 
 public class PatronServicesResourceImpl implements Patron {
-  private final Logger logger = LogManager.getLogger();
 
   @Validate
   @Override

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -100,6 +100,7 @@ public class PatronResourceImplTest {
   private final String book2Barcode = "1234567891";
   private final String book3Barcode = "1234567892";
   private final String cameraBarcode = "1234567893";
+  private final String feeFineNoItemId = "771b629b-e2c4-4711-b9d7-091af40f6b8b";
   private final String feeFineOverdueId = "cdf3970f-7ed2-4dae-8ae3-a8250a83a9a0";
   private final String feeFineDamageBookId = "881c628b-e1c4-4711-b9d7-090af40f6a8f";
   private final String feeFineDamageEquipmentId = "ca295e87-223f-403c-9eee-a152c47bf67f";
@@ -450,6 +451,11 @@ public class PatronResourceImplTest {
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
+      } else if (req.path().equals("/feefines/" + feeFineNoItemId)) {
+        req.response()
+          .setStatusCode(200)
+          .putHeader("content-type", "application/json")
+          .end(readMockFile(mockDataFolder + "/feefine_no_item.json"));
       } else if (req.path().equals("/feefines/" + feeFineOverdueId)) {
         req.response()
           .setStatusCode(200)
@@ -570,6 +576,7 @@ public class PatronResourceImplTest {
           .extract().response();
 
     final String body = r.getBody().asString();
+    logger.info("response: " + body);
     final JsonObject json = new JsonObject(body);
     final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder + "/response_testGetPatronAccountById.json"));
 
@@ -580,16 +587,16 @@ public class PatronResourceImplTest {
     assertEquals(3, json.getJsonArray("holds").size());
 
     JsonObject money = json.getJsonObject("totalCharges");
-    assertEquals(155.0, money.getDouble("amount"));
+    assertEquals(255.0, money.getDouble("amount"));
     assertEquals("USD", money.getString("isoCurrencyCode"));
-    assertEquals(4, json.getInteger("totalChargesCount"));
-    assertEquals(4, json.getJsonArray("charges").size());
+    assertEquals(5, json.getInteger("totalChargesCount"));
+    assertEquals(5, json.getJsonArray("charges").size());
 
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 5; i++) {
       final JsonObject jo = json.getJsonArray("charges").getJsonObject(i);
 
       boolean found = false;
-      for (int j = 0; j < 4; j++) {
+      for (int j = 0; j < 5; j++) {
         final JsonObject expectedJO = expectedJson.getJsonArray("charges").getJsonObject(j);
         if (verifyCharge(expectedJO, jo)) {
           found = true;
@@ -667,9 +674,9 @@ public class PatronResourceImplTest {
     assertEquals(0, json.getJsonArray("holds").size());
 
     final JsonObject money = json.getJsonObject("totalCharges");
-    assertEquals(155.0, money.getDouble("amount"));
+    assertEquals(255.0, money.getDouble("amount"));
     assertEquals("USD", money.getString("isoCurrencyCode"));
-    assertEquals(4, json.getInteger("totalChargesCount"));
+    assertEquals(5, json.getInteger("totalChargesCount"));
     assertEquals(0, json.getJsonArray("charges").size());
 
     // Test done
@@ -1222,10 +1229,12 @@ public class PatronResourceImplTest {
     if (expectedCharge.getString("accrualDate").equals(actualCharge.getString("accrualDate"))) {
       assertEquals(expectedCharge.getString("state"), actualCharge.getString("state"));
       assertEquals(expectedCharge.getString("reason"), actualCharge.getString("reason"));
-
       verifyAmount(expectedCharge.getJsonObject("chargeAmount"), actualCharge.getJsonObject("chargeAmount"));
-
-      return verifyItem(expectedCharge.getJsonObject("item"), actualCharge.getJsonObject("item"));
+      if (expectedCharge.getJsonObject("item") != null) {
+        return verifyItem(expectedCharge.getJsonObject("item"), actualCharge.getJsonObject("item"));
+      } else {
+        return true;
+      }
     }
 
     return false;

--- a/src/test/resources/PatronServicesResourceImpl/accounts_all.json
+++ b/src/test/resources/PatronServicesResourceImpl/accounts_all.json
@@ -1,5 +1,22 @@
 {
-  "accounts": [ {
+  "accounts": [{ 
+    "amount": 100.0,
+    "remaining": 100.0,
+    "dateCreated": "2018-01-30T00:00:01Z",
+    "dateUpdated": "2018-01-30T00:00:01Z",
+    "status": {
+      "name": "Open"
+    },
+    "paymentStatus": {
+      "name": "Unpaid"
+    },
+    "feeFineType": "no item",
+    "feeFineOwner": "Main library Ciculation Desk",
+    "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+    "feeFineId": "771b629b-e2c4-4711-b9d7-091af40f6b8b",
+    "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8",
+    "id": "749cf599-3a33-474e-8fa4-268a5b66fddf"
+  },{
     "amount": 100.0,
     "remaining": 50.0,
     "accountTransaction": 1,
@@ -108,5 +125,5 @@
     "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8",
     "id": "749bf599-3a31-494e-9fa4-268a5b67fdde"
   } ],
-  "totalRecords": 4
+  "totalRecords": 5
 }

--- a/src/test/resources/PatronServicesResourceImpl/feefine_no_item.json
+++ b/src/test/resources/PatronServicesResourceImpl/feefine_no_item.json
@@ -1,0 +1,8 @@
+{
+  "feeFineType": "no item",
+  "id": "771b629b-e2c4-4711-b9d7-091af40f6b8b",
+  "defaultAmount": 100,
+  "allowManualCreation": true,
+  "taxVat": 7,
+  "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8"
+}

--- a/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById.json
@@ -1,12 +1,21 @@
 {
     "totalCharges": {
-        "amount": 155.0,
+        "amount": 255.0,
         "isoCurrencyCode": "USD"
     },
-    "totalChargesCount": 4,
+    "totalChargesCount": 5,
     "totalLoans": 3,
     "totalHolds": 3,
     "charges": [
+      {
+        "chargeAmount" : {
+          "amount" : 100.0,
+          "isoCurrencyCode" : "USD"
+        },
+        "accrualDate" : "2018-01-30T00:00:01.000+0000",
+        "state" : "Unpaid",
+        "reason" : "no item"
+      },
       {
         "item" : {
           "instanceId" : "6e024cd5-c19a-4fe0-a2cd-64ce5814c694",
@@ -20,8 +29,7 @@
         },
         "accrualDate" : "2018-01-31T00:00:01.000+0000",
         "state" : "Paid Partially",
-        "reason" : "damage - rebinding",
-        "feeFineId" : "881c628b-e1c4-4711-b9d7-090af40f6a8f"
+        "reason" : "damage - rebinding"
       }, {
         "item" : {
           "instanceId" : "75d0799a-66d8-46cf-a7e3-ed7390425112",
@@ -35,8 +43,7 @@
         },
         "accrualDate" : "2018-04-30T00:00:01.000+0000",
         "state" : "Unpaid",
-        "reason" : "overdue",
-        "feeFineId" : "cdf3970f-7ed2-4dae-8ae3-a8250a83a9a0"
+        "reason" : "overdue"
       }, {
         "item" : {
           "instanceId" : "f3482bed-a7e9-4f07-beb0-ebd693331350",
@@ -50,8 +57,7 @@
         },
         "accrualDate" : "2018-05-31T00:00:01.000+0000",
         "state" : "Paid Partially",
-        "reason" : "overdue",
-        "feeFineId" : "cdf3970f-7ed2-4dae-8ae3-a8250a83a9a0"
+        "reason" : "overdue"
       }, {
         "item" : {
           "instanceId" : "c394b514-9fd0-496d-ab9a-aec777facc1b",


### PR DESCRIPTION
Traced this problem to code in getPatronAccountById method of 
PatronServicesResourceImpl class.  The code had been written in such
a way that it expected every charge to have item data attached.  When
there was none, the code would assign a null value to the item Id field, then
when that object got passed to the item lookup function, a search for data
on that item would result in an error which got pushed up to the API endpoint.

I rewrote the code to skip item lookup for charges with no item data.  I also 
adjusted the test on this endpoint to include an account with no item data.

I also noticed that the endpoint does not seem to supply feeFine identifiers
for charges, yet the test file used for comparison had that data in the 
expected response-even though none of the tests checked for it's presence.  
So I removed that data from the model file.
