### PR TITLE
Modpatron 53

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aspectj.version>1.9.6</aspectj.version>
     <raml-module-builder.version>32.1.0</raml-module-builder.version>
+    <vertx.version>4.0.0</vertx.version>
   </properties>
 
   <repositories>
@@ -84,6 +85,10 @@
       <version>${raml-module-builder.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>
@@ -104,7 +109,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
-      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -478,6 +482,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aspectj.version>1.9.6</aspectj.version>
-    <raml-module-builder.version>32.1.0</raml-module-builder.version>
-    <vertx.version>4.0.0</vertx.version>
+    <raml-module-builder.version>33.0.0</raml-module-builder.version>
+    <vertx.version>4.1.0.CR1</vertx.version>
   </properties>
 
   <repositories>
@@ -109,6 +109,11 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.10.9</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>vertx-web-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aspectj.version>1.9.6</aspectj.version>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <raml-module-builder.version>33.0.2</raml-module-builder.version>
+    <vertx.version>4.1.0</vertx.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,14 @@
     </repository>
   </repositories>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>folio-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://repository.folio.org/repository/maven-folio</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <distributionManagement>
     <repository>
       <id>folio-nexus</id>
@@ -192,54 +200,15 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <groupId>org.folio</groupId>
+        <artifactId>domain-models-maven-plugin</artifactId>
+        <version>${raml-module-builder.version}</version>
         <executions>
           <execution>
             <id>generate_interfaces</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>java</goal>
             </goals>
-            <configuration>
-              <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
-              <cleanupDaemonThreads>false</cleanupDaemonThreads>
-              <systemProperties>
-                <systemProperty>
-                  <key>project.basedir</key>
-                  <value>${basedir}</value>
-                </systemProperty>
-                <systemProperty>
-                  <key>raml_files</key>
-                  <value>${ramlfiles_path}</value>
-                </systemProperty>
-                <systemProperty>
-                  <key>jsonschema2pojo.config.includeToString</key>
-                  <value>true</value>
-                </systemProperty>
-                <systemProperty>
-                  <key>jsonschema2pojo.config.includeHashcodeAndEquals</key>
-                  <value>true</value>
-                </systemProperty>
-              </systemProperties>
-            </configuration>
-          </execution>
-          <execution>
-            <id>git submodule update</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>git</executable>
-              <arguments>
-                <argument>submodule</argument>
-                <argument>update</argument>
-                <argument>--init</argument>
-                <argument>--recursive</argument>
-              </arguments>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -84,7 +84,9 @@ class LookupsUtils {
     }
   }
 
-  private static CompletableFuture<LookupsUtils.Response> get (String path, Map<String, String> okapiHeaders) {
+  private static CompletableFuture<LookupsUtils.Response> get (String path,
+   Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
+
     Vertx vertx = Vertx.currentContext().owner();
     URL url;
 
@@ -97,13 +99,22 @@ class LookupsUtils {
     final var futureResponse
       = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
 
-    WebClient.create(vertx)
-      .get(url.getPort(), url.getHost(), url.getPath())
-      .putHeaders(buildHeaders(okapiHeaders))
-      .send(futureResponse::complete);
+    final var request = WebClient.create(vertx)
+      .put(url.getPort(), url.getHost(), url.getPath())
+      .putHeaders(buildHeaders(okapiHeaders));
+
+    queryParameters.forEach(request::addQueryParam);
+
+    request.send(futureResponse::complete);
 
     return futureResponse
       .thenCompose(LookupsUtils::toResponse);
+  }
+
+  private static CompletableFuture<LookupsUtils.Response> get (String path,
+    Map<String, String> okapiHeaders) {
+
+    return get(path, Map.of(), okapiHeaders);
   }
 
   private static CompletableFuture<LookupsUtils.Response> toResponse(

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -29,7 +29,7 @@ class LookupsUtils {
   }
 
   static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
-    return get("/users/" + userId, getHttpClient(okapiHeaders), okapiHeaders)
+    return get("/users/" + userId, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -24,7 +24,7 @@ class LookupsUtils {
   private LookupsUtils() {}
 
   static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders) {
-    return get("/inventory/items/" + itemId, getHttpClient(okapiHeaders), okapiHeaders)
+    return get("/inventory/items/" + itemId, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -102,8 +102,8 @@ class LookupsUtils {
       .thenCompose(LookupsUtils::toResponse);
   }
 
-  private static CompletableFuture<LookupsUtils.Response> get (String path,
-    Map<String, String> okapiHeaders) {
+  public static CompletableFuture<LookupsUtils.Response> get(String path,
+                                                             Map<String, String> okapiHeaders) {
 
     return get(path, Map.of(), okapiHeaders);
   }

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -75,7 +75,7 @@ class LookupsUtils {
     return HttpClientFactory.getHttpClient(okapiURL, tenantId);
   }
 
-  private static CompletableFuture<LookupsUtils.Response> get (String path,
+  public static CompletableFuture<LookupsUtils.Response> get (String path,
    Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
 
     Vertx vertx = Vertx.currentContext().owner();

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -13,30 +13,27 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 class LookupsUtils {
+  private LookupsUtils() {}
 
-  private LookupsUtils(){}
-
-  static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders,
-                                               HttpClientInterface httpClient) {
-    return get("/inventory/items/" + itemId, httpClient, okapiHeaders)
+  static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders) {
+    return get("/inventory/items/" + itemId, getHttpClient(okapiHeaders), okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders,
-                                               HttpClientInterface httpClient) {
-    return get("/users/" + userId, httpClient, okapiHeaders)
+  static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
+    return get("/users/" + userId, getHttpClient(okapiHeaders), okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static CompletableFuture<JsonObject> getRequestPolicyId(String queryString, Map<String, String> okapiHeaders,
-                                                          HttpClientInterface httpClient) {
-    return get("/circulation/rules/request-policy?" + queryString, httpClient, okapiHeaders)
+  static CompletableFuture<JsonObject> getRequestPolicyId(String queryString, Map<String, String> okapiHeaders) {
+    return get("/circulation/rules/request-policy?" + queryString,
+        getHttpClient(okapiHeaders), okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders,
-                                                        HttpClientInterface httpClient) {
-    return get("/request-policy-storage/request-policies/" + requestPolicyId, httpClient, okapiHeaders)
+  static CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders) {
+    return get("/request-policy-storage/request-policies/" + requestPolicyId,
+        getHttpClient(okapiHeaders), okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
@@ -57,8 +54,8 @@ class LookupsUtils {
   }
 
   private static CompletableFuture<Response> get (String path,
-                                                        HttpClientInterface httpClient,
-                                                        Map<String, String> okapiHeaders) {
+    HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
+
     try {
       return httpClient.request(path, okapiHeaders);
     } catch (Exception e) {

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.patron.rest.exceptions.HttpException;
 
 import io.vertx.core.AsyncResult;

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -75,16 +75,6 @@ class LookupsUtils {
     return HttpClientFactory.getHttpClient(okapiURL, tenantId);
   }
 
-  private static CompletableFuture<org.folio.rest.tools.client.Response> get (String path,
-    HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
-
-    try {
-      return httpClient.request(path, okapiHeaders);
-    } catch (Exception e) {
-      throw new CompletionException(e);
-    }
-  }
-
   private static CompletableFuture<LookupsUtils.Response> get (String path,
    Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
 
@@ -106,13 +96,10 @@ class LookupsUtils {
 
     queryParameters.forEach(request::addQueryParam);
 
-    request
-      .timeout(1000)
-      .send(futureResponse::complete);
+    request.send(futureResponse::complete);
 
     return futureResponse
-      .thenCompose(LookupsUtils::toResponse)
-      .exceptionally(t -> null);
+      .thenCompose(LookupsUtils::toResponse);
   }
 
   private static CompletableFuture<LookupsUtils.Response> get (String path,

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -33,7 +33,12 @@ class LookupsUtils {
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static CompletableFuture<JsonObject> getRequestPolicyId(String queryString, Map<String, String> okapiHeaders) {
+  static CompletableFuture<JsonObject> getRequestPolicyId(RequestTypeParameters criteria, Map<String, String> okapiHeaders) {
+    String queryString = String.format(
+      "item_type_id=%s&loan_type_id=%s&patron_type_id=%s&location_id=%s",
+      criteria.getItemMaterialTypeId(), criteria.getItemLoanTypeId(),
+      criteria.getPatronGroupId(), criteria.getItemLocationId());
+
     return get("/circulation/rules/request-policy?" + queryString,
         getHttpClient(okapiHeaders), okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -111,8 +111,7 @@ class LookupsUtils {
       .sendJson(body, futureResponse::complete);
 
     return futureResponse
-      .thenCompose(LookupsUtils::toResponse)
-      .exceptionally(t -> null);
+      .thenCompose(LookupsUtils::toResponse);
   }
 
   public static CompletableFuture<LookupsUtils.Response> get(String path,

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -1,16 +1,24 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.json.JsonObject;
-import org.folio.patron.rest.exceptions.HttpException;
-import org.folio.rest.RestVerticle;
-import org.folio.rest.tools.client.HttpClientFactory;
-import org.folio.rest.tools.client.Response;
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
-import org.folio.rest.tools.utils.TenantTool;
-
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+
+import org.folio.patron.rest.exceptions.HttpException;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.client.HttpClientFactory;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+import org.folio.rest.tools.utils.TenantTool;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
 
 class LookupsUtils {
   private LookupsUtils() {}
@@ -32,18 +40,26 @@ class LookupsUtils {
   }
 
   static CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders) {
-    return get("/request-policy-storage/request-policies/" + requestPolicyId,
-        getHttpClient(okapiHeaders), okapiHeaders)
+    return get("/request-policy-storage/request-policies/" + requestPolicyId, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static JsonObject verifyAndExtractBody(Response response) {
-    if (!Response.isSuccess(response.getCode())) {
+  static JsonObject verifyAndExtractBody(org.folio.rest.tools.client.Response response) {
+    if (!org.folio.rest.tools.client.Response.isSuccess(response.getCode())) {
       throw new CompletionException(new HttpException(response.getCode(),
         response.getError().getString("errorMessage")));
     }
 
     return response.getBody();
+  }
+
+  static JsonObject verifyAndExtractBody(Response response) {
+    if (!response.isSuccess()) {
+      throw new CompletionException(new HttpException(response.statusCode,
+        response.body));
+    }
+
+    return new JsonObject(response.body);
   }
 
   static HttpClientInterface getHttpClient(Map<String, String> okapiHeaders) {
@@ -53,13 +69,75 @@ class LookupsUtils {
     return HttpClientFactory.getHttpClient(okapiURL, tenantId);
   }
 
-  private static CompletableFuture<Response> get (String path,
+  private static CompletableFuture<org.folio.rest.tools.client.Response> get (String path,
     HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
 
     try {
       return httpClient.request(path, okapiHeaders);
     } catch (Exception e) {
       throw new CompletionException(e);
+    }
+  }
+
+  private static CompletableFuture<LookupsUtils.Response> get (String path, Map<String, String> okapiHeaders) {
+    Vertx vertx = Vertx.currentContext().owner();
+    URL url;
+
+    try {
+      url = new URL(buildUri(path, okapiHeaders));
+    } catch (MalformedURLException e) {
+      throw new CompletionException(e.getCause());
+    }
+
+    final var futureResponse
+      = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
+
+    WebClient.create(vertx)
+      .get(url.getPort(), url.getHost(), url.getPath())
+      .putHeaders(buildHeaders(okapiHeaders))
+      .send(futureResponse::complete);
+
+    return futureResponse
+      .thenCompose(LookupsUtils::toResponse);
+  }
+
+  private static CompletableFuture<LookupsUtils.Response> toResponse(
+    AsyncResult<HttpResponse<Buffer>> result) {
+
+    if (result.failed()) {
+      return CompletableFuture.failedFuture(result.cause());
+    }
+
+    final var response = result.result();
+
+    final var mappedResponse = new Response(response.statusCode(),
+      response.bodyAsString());
+
+    return CompletableFuture.completedFuture(mappedResponse);
+  }
+
+  private static String buildUri(String path, Map<String, String> okapiHeaders) {
+    final String okapiURL = okapiHeaders.getOrDefault("X-Okapi-Url", "");
+
+    return okapiURL + path;
+  }
+
+  private static MultiMap buildHeaders(Map<String, String> okapiHeaders) {
+    return MultiMap.caseInsensitiveMultiMap()
+      .addAll(okapiHeaders);
+  }
+
+  public static class Response {
+    public final int statusCode;
+    public final String body;
+
+    public Response(int statusCode, String body) {
+      this.statusCode = statusCode;
+      this.body = body;
+    }
+
+    public boolean isSuccess() {
+      return statusCode >= 200 && statusCode < 300;
     }
   }
 }

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -49,7 +49,7 @@ public class PatronServicesResourceImpl implements Patron {
     final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     try {
       // Look up the user to ensure that the user exists and is enabled
-        LookupsUtils.getUser(id, okapiHeaders, httpClient)
+        LookupsUtils.getUser(id, okapiHeaders)
         .thenAccept(this::verifyUserEnabled)
         .thenCompose(v -> {
           try {
@@ -141,7 +141,7 @@ public class PatronServicesResourceImpl implements Patron {
     final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     RequestObjectFactory requestFactory = new RequestObjectFactory(okapiHeaders);
 
-    requestFactory.createRequestByItem(id, itemId, entity, httpClient)
+    requestFactory.createRequestByItem(id, itemId, entity)
       .thenCompose(holdJSON -> {
         try {
           if (holdJSON == null) {
@@ -403,7 +403,7 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<Account> lookupItem(HttpClientInterface httpClient, Charge charge, Account account, Map<String, String> okapiHeaders) {
-    return getItem(charge, okapiHeaders, httpClient)
+    return getItem(charge, okapiHeaders)
         .thenCompose(item ->getHoldingsRecord(item, httpClient, okapiHeaders))
         .thenApply(LookupsUtils::verifyAndExtractBody)
         .thenCompose(holding -> getInstance(holding, httpClient, okapiHeaders))
@@ -412,9 +412,9 @@ public class PatronServicesResourceImpl implements Patron {
         .thenApply(item -> updateItem(charge, item, account));
   }
 
-  private CompletableFuture<JsonObject> getItem(Charge charge, Map<String, String> okapiHeaders, HttpClientInterface httpClient) {
+  private CompletableFuture<JsonObject> getItem(Charge charge, Map<String, String> okapiHeaders) {
 
-    return LookupsUtils.getItem(charge.getItem().getItemId(), okapiHeaders, httpClient);
+    return LookupsUtils.getItem(charge.getItem().getItemId(), okapiHeaders);
   }
 
   private CompletableFuture<Response> getHoldingsRecord(JsonObject item,

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -61,7 +61,7 @@ public class PatronServicesResourceImpl implements Patron {
             final CompletableFuture<Account> cf1 = getLoans(id, includeLoans, okapiHeaders)
                 .thenApply(body -> addLoans(account, body, includeLoans));
 
-            final CompletableFuture<Account> cf2 = getRequests(id, includeHolds, okapiHeaders, httpClient)
+            final CompletableFuture<Account> cf2 = getRequests(id, includeHolds, okapiHeaders)
                 .thenApply(body -> addHolds(account, body, includeHolds));
 
             final CompletableFuture<Account> cf3 = getAccounts(id, okapiHeaders, httpClient)
@@ -108,10 +108,13 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<JsonObject> getRequests(String id, boolean includeHolds,
-    Map<String, String> okapiHeaders, HttpClientInterface httpClient) throws Exception {
+    Map<String, String> okapiHeaders) {
 
-    return httpClient.request("/circulation/requests?limit=" + getLimit(includeHolds)
-        + "&query=%28requesterId%3D%3D" + id + "%20and%20status%3D%3DOpen%2A%29", okapiHeaders)
+    final var queryParameters = Map.of(
+      "limit", String.valueOf(getLimit(includeHolds)),
+      "query", String.format("(requesterId==%s and status==Open*)", id));
+
+    return LookupsUtils.get("/circulation/requests", queryParameters, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -135,24 +135,20 @@ public class PatronServicesResourceImpl implements Patron {
         .put(Constants.JSON_FIELD_ITEM_ID, itemId)
         .put(Constants.JSON_FIELD_USER_ID, id);
 
-    final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     try {
-      httpClient.request(HttpMethod.POST, Buffer.buffer(renewalJSON.toString()), "/circulation/renew-by-id", okapiHeaders)
+      LookupsUtils.post("/circulation/renew-by-id", renewalJSON, okapiHeaders)
           .thenApply(LookupsUtils::verifyAndExtractBody)
           .thenAccept(body -> {
             final Item item = getItem(itemId, body.getJsonObject(Constants.JSON_FIELD_ITEM));
             final Loan hold = getLoan(body, item);
             asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountItemRenewByIdAndItemIdResponse.respond201WithApplicationJson(hold)));
-            httpClient.closeClient();
           })
           .exceptionally(throwable -> {
             asyncResultHandler.handle(handleRenewPOSTError(throwable));
-            httpClient.closeClient();
             return null;
           });
     } catch (Exception e) {
       asyncResultHandler.handle(Future.succeededFuture(PostPatronAccountItemRenewByIdAndItemIdResponse.respond500WithTextPlain(e.getMessage())));
-      httpClient.closeClient();
     }
   }
 

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -58,7 +58,7 @@ public class PatronServicesResourceImpl implements Patron {
             account.setTotalCharges(new TotalCharges().withAmount(0.0).withIsoCurrencyCode("USD"));
             account.setTotalChargesCount(0);
 
-            final CompletableFuture<Account> cf1 = getLoans(id, includeLoans, okapiHeaders, httpClient)
+            final CompletableFuture<Account> cf1 = getLoans(id, includeLoans, okapiHeaders)
                 .thenApply(body -> addLoans(account, body, includeLoans));
 
             final CompletableFuture<Account> cf2 = getRequests(id, includeHolds, okapiHeaders, httpClient)
@@ -116,10 +116,13 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<JsonObject> getLoans(String id, boolean includeLoans,
-    Map<String, String> okapiHeaders, HttpClientInterface httpClient) throws Exception {
+    Map<String, String> okapiHeaders) {
 
-    return httpClient.request("/circulation/loans?limit=" + getLimit(includeLoans)
-        + "&query=%28userId%3D%3D" + id + "%20and%20status.name%3D%3DOpen%29", okapiHeaders)
+    final var queryParameters = Map.of(
+      "limit", String.valueOf(getLimit(includeLoans)),
+      "query", String.format("(userId==%s and status.name==Open)", id));
+
+    return LookupsUtils.get("/circulation/loans", queryParameters, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -432,7 +432,7 @@ public class PatronServicesResourceImpl implements Patron {
 
   private CompletableFuture<Account> lookupItem(HttpClientInterface httpClient, Charge charge, Account account, Map<String, String> okapiHeaders) {
     return getItem(charge, okapiHeaders)
-        .thenCompose(item ->getHoldingsRecord(item, httpClient, okapiHeaders))
+        .thenCompose(item -> getHoldingsRecord(item, okapiHeaders))
         .thenApply(LookupsUtils::verifyAndExtractBody)
         .thenCompose(holding -> getInstance(holding, httpClient, okapiHeaders))
         .thenApply(LookupsUtils::verifyAndExtractBody)
@@ -445,10 +445,14 @@ public class PatronServicesResourceImpl implements Patron {
     return LookupsUtils.getItem(charge.getItem().getItemId(), okapiHeaders);
   }
 
-  private CompletableFuture<Response> getHoldingsRecord(JsonObject item,
-      HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
+  private CompletableFuture<LookupsUtils.Response> getHoldingsRecord(
+    JsonObject item, Map<String, String> okapiHeaders) {
+
     try {
-      return httpClient.request("/holdings-storage/holdings/" + item.getString("holdingsRecordId"), okapiHeaders);
+      return LookupsUtils.get(
+        "/holdings-storage/holdings/" + item.getString("holdingsRecordId"),
+        okapiHeaders);
+
     } catch (Exception e) {
       throw new CompletionException(e);
     }

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -64,7 +64,7 @@ public class PatronServicesResourceImpl implements Patron {
             final CompletableFuture<Account> cf2 = getRequests(id, includeHolds, okapiHeaders)
                 .thenApply(body -> addHolds(account, body, includeHolds));
 
-            final CompletableFuture<Account> cf3 = getAccounts(id, okapiHeaders, httpClient)
+            final CompletableFuture<Account> cf3 = getAccounts(id, okapiHeaders)
                 .thenApply(body -> addCharges(account, body, includeCharges))
                 .thenCompose(charges -> {
                   if (includeCharges) {
@@ -99,11 +99,12 @@ public class PatronServicesResourceImpl implements Patron {
     }
   }
 
-  private CompletableFuture<JsonObject> getAccounts(String id,
-    Map<String, String> okapiHeaders, HttpClientInterface httpClient) throws Exception {
+  private CompletableFuture<JsonObject> getAccounts(String id, Map<String, String> okapiHeaders) {
+    final var queryParameters = Map.of(
+      "limit", String.valueOf(getLimit(true)),
+      "query", String.format("(userId==%s and status.name==Open)", id));
 
-    return httpClient.request("/accounts?limit=" + getLimit(true)
-        + "&query=%28userId%3D%3D" + id + "%20and%20status.name%3D%3DOpen%29", okapiHeaders)
+    return LookupsUtils.get("/accounts", queryParameters, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -50,7 +50,7 @@ class RequestObjectFactory {
 
     return CompletableFuture.allOf(userFuture, itemFuture)
       .thenApply(x -> createRequestPolicyIdCriteria(itemFuture, userFuture, requestTypeParams))
-      .thenCompose((RequestTypeParameters criteria) -> lookupRequestPolicyId(criteria))
+      .thenCompose(this::lookupRequestPolicyId)
       .thenCompose(policyIdResponse ->
           LookupsUtils.getRequestPolicy(policyIdResponse.getString("requestPolicyId"), okapiHeaders))
       .thenApply(RequestPolicy::from)
@@ -69,13 +69,7 @@ class RequestObjectFactory {
   }
 
   private CompletableFuture<JsonObject> lookupRequestPolicyId(RequestTypeParameters criteria) {
-    String queryString = String.format(
-      "item_type_id=%s&loan_type_id=%s&patron_type_id=%s&location_id=%s",
-      criteria.getItemMaterialTypeId(), criteria.getItemLoanTypeId(),
-      criteria.getPatronGroupId(), criteria.getItemLocationId()
-    );
-
-    return LookupsUtils.getRequestPolicyId(queryString, okapiHeaders);
+    return LookupsUtils.getRequestPolicyId(criteria, okapiHeaders);
   }
 
   private RequestTypeParameters createRequestPolicyIdCriteria(CompletableFuture<JsonObject> itemFuture,

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -54,8 +54,7 @@ class RequestObjectFactory {
       .thenCompose(policyIdResponse ->
           LookupsUtils.getRequestPolicy(policyIdResponse.getString("requestPolicyId"), okapiHeaders))
       .thenApply(RequestPolicy::from)
-      .thenApply(requestPolicy -> getRequestType(requestPolicy, requestTypeParams.getItemStatus()))
-      .exceptionally(t -> null);
+      .thenApply(requestPolicy -> getRequestType(requestPolicy, requestTypeParams.getItemStatus()));
   }
 
   private RequestType getRequestType(RequestPolicy policy,  ItemStatus itemStatus) {

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -54,7 +54,8 @@ class RequestObjectFactory {
       .thenCompose(policyIdResponse ->
           LookupsUtils.getRequestPolicy(policyIdResponse.getString("requestPolicyId"), okapiHeaders))
       .thenApply(RequestPolicy::from)
-      .thenApply(requestPolicy -> getRequestType(requestPolicy, requestTypeParams.getItemStatus()));
+      .thenApply(requestPolicy -> getRequestType(requestPolicy, requestTypeParams.getItemStatus()))
+      .exceptionally(t -> null);
   }
 
   private RequestType getRequestType(RequestPolicy policy,  ItemStatus itemStatus) {

--- a/src/test/java/org/folio/rest/impl/HoldHelpersTest.java
+++ b/src/test/java/org/folio/rest/impl/HoldHelpersTest.java
@@ -28,7 +28,7 @@ class HoldHelpersTest {
     final String cancellationReasonId = "dd238b5b-01fc-4205-83b8-888888888888";
     final String requestId = "dd238b5b-01fc-4205-83b8-888888888888";
     final String holdCancellationReason = "I really don't want it anymore";
-    final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSZ");
+    final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
     Date canceledDate = DateTime.now().toDate();
     String canceledDateString = formatter.format(canceledDate);

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -17,7 +17,6 @@ import org.folio.okapi.common.UrlDecoder;
 import org.folio.patron.utils.Utils;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.model.Hold;
 import org.folio.rest.tools.utils.ModuleName;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
@@ -922,7 +921,7 @@ public class PatronResourceImplTest {
 
     String aBody = readMockFile(mockDataFolder + "/hold_cancel_request.json");
 
-    final Hold holdCancelResponse = given()
+    final var holdCancelResponse = given()
         .header(tenantHeader)
         .header(urlHeader)
         .header(contentTypeHeader)
@@ -938,10 +937,12 @@ public class PatronResourceImplTest {
         .and().assertThat().contentType(ContentType.JSON)
         .and().assertThat().statusCode(200)
       .extract()
-        .as(Hold.class);
+        .asString();
 
-    final Hold expectedHold = Json.decodeValue(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"), Hold.class);
-    assertEquals(expectedHold, holdCancelResponse);
+    final var expectedHold = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"));
+
+    verifyHold(expectedHold, new JsonObject(holdCancelResponse));
+
     // Test done
     logger.info("Test done");
   }
@@ -955,7 +956,7 @@ public class PatronResourceImplTest {
     jsonBody.remove("cancelledDate");
     aBody = jsonBody.encodePrettily();
 
-    final Hold holdCancelResponse = given()
+    final var holdCancelResponse = given()
         .header(tenantHeader)
         .header(urlHeader)
         .header(contentTypeHeader)
@@ -972,10 +973,12 @@ public class PatronResourceImplTest {
         .and().assertThat().contentType(ContentType.JSON)
         .and().assertThat().statusCode(200)
       .extract()
-        .as(Hold.class);
+        .asString();
 
-    final Hold expectedHold = Json.decodeValue(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"), Hold.class);
-    assertEquals(expectedHold, holdCancelResponse);
+    final var expectedHold = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"));
+
+    verifyHold(expectedHold, new JsonObject(holdCancelResponse));
+
     // Test done
     logger.info("Test done");
   }
@@ -1005,8 +1008,14 @@ public class PatronResourceImplTest {
       .extract()
         .as(Errors.class);
 
-    final Errors expectedErrors = Json.decodeValue(readMockFile(mockDataFolder + "/hold_cancel_error.json"), Errors.class);
-    assertEquals(expectedErrors, holdErrorResponse);
+    assertEquals(1, holdErrorResponse.getErrors().size());
+    assertEquals("Cannot edit a closed request",
+      holdErrorResponse.getErrors().get(0).getMessage());
+    assertEquals(1, holdErrorResponse.getErrors().get(0).getParameters().size());
+    assertEquals("id",
+      holdErrorResponse.getErrors().get(0).getParameters().get(0).getKey());
+    assertEquals("69f059dd-e8ad-43a9-b2d7-d35a0ad3ab1b",
+      holdErrorResponse.getErrors().get(0).getParameters().get(0).getValue());
 
     // Test done
     logger.info("Test done");
@@ -1016,7 +1025,7 @@ public class PatronResourceImplTest {
   public final void testPostPatronAccountByIdInstanceByInstanceIdHold() {
     logger.info("Testing creating a hold on an instance for the specified user");
 
-    final Hold hold = given()
+    final var hold = given()
         .headers(new Headers(tenantHeader, urlHeader, contentTypeHeader))
         .and().pathParams("accountId", goodUserId, "instanceId", goodInstanceId)
         .and().body(readMockFile(mockDataFolder
@@ -1028,11 +1037,11 @@ public class PatronResourceImplTest {
         .and().assertThat().contentType(ContentType.JSON)
         .and().assertThat().statusCode(201)
       .extract()
-        .as(Hold.class);
+        .asString();
 
-    final Hold expectedHold = Json.decodeValue(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdInstanceByInstanceIdHold.json"), Hold.class);
+    final var expectedHold = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdInstanceByInstanceIdHold.json"));
 
-    assertEquals(expectedHold, hold);
+    verifyHold(expectedHold, new JsonObject(hold));
 
     // Test done
     logger.info("Test done");
@@ -1084,8 +1093,14 @@ public class PatronResourceImplTest {
       .extract()
         .as(Errors.class);
 
-    final var expectedErrors = Json.decodeValue(readMockFile(mockDataFolder + "/instance_hold_bad_instance_id.json"), Errors.class);
-    assertEquals(expectedErrors, holdErrorResponse);
+    assertEquals(1, holdErrorResponse.getErrors().size());
+    assertEquals("No instance with ID 68cb9692-aa5f-459d-8791-f79486c11225 exists",
+      holdErrorResponse.getErrors().get(0).getMessage());
+    assertEquals(1, holdErrorResponse.getErrors().get(0).getParameters().size());
+    assertEquals("instanceId",
+      holdErrorResponse.getErrors().get(0).getParameters().get(0).getKey());
+    assertEquals("68cb9692-aa5f-459d-8791-f79486c11225",
+      holdErrorResponse.getErrors().get(0).getParameters().get(0).getValue());
   }
 
   @Test
@@ -1108,8 +1123,14 @@ public class PatronResourceImplTest {
         .extract()
         .as(Errors.class);
 
-    final var expectedErrors = Json.decodeValue(readMockFile(mockDataFolder + "/item_hold_bad_item_id.json"), Errors.class);
-    assertEquals(expectedErrors, holdErrorResponse);
+    assertEquals(1, holdErrorResponse.getErrors().size());
+    assertEquals("No item with ID 3dda4eb9-a156-474c-829f-bd5a386f382c",
+      holdErrorResponse.getErrors().get(0).getMessage());
+    assertEquals(1, holdErrorResponse.getErrors().get(0).getParameters().size());
+    assertEquals("itemId",
+      holdErrorResponse.getErrors().get(0).getParameters().get(0).getKey());
+    assertEquals("3dda4eb9-a156-474c-829f-bd5a386f382c",
+      holdErrorResponse.getErrors().get(0).getParameters().get(0).getValue());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -221,12 +221,12 @@ public class PatronResourceImplTest {
             });
           }
         } else {
-            if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20status%%3D%%3DOpen%%2A%%29", Integer.MAX_VALUE, goodUserId))) {
+            if (requestsParametersMatch(req, Integer.MAX_VALUE)) {
               req.response()
                 .setStatusCode(200)
                 .putHeader("content-type", "application/json")
                 .end(readMockFile(mockDataFolder + "/holds_all.json"));
-            } else if (req.query().equals(String.format("limit=%d&query=%%28requesterId%%3D%%3D%s%%20and%%20status%%3D%%3DOpen%%2A%%29", 1, goodUserId))) {
+            } else if (requestsParametersMatch(req, 1)) {
               req.response()
                 .setStatusCode(200)
                 .putHeader("content-type", "application/json")
@@ -540,6 +540,13 @@ public class PatronResourceImplTest {
       }
     });
     server.listen(serverPort, host, context.succeeding(id -> mockOkapiStarted.flag()));
+  }
+
+  private boolean requestsParametersMatch(HttpServerRequest request, int limit) {
+    final var queryString = UrlDecoder.decode(request.query());
+
+    return queryString.contains("limit=" + limit)
+      && queryString.contains("query=(requesterId==" + goodUserId + " and status==Open*)");
   }
 
   private boolean loansParametersMatch(HttpServerRequest request, int limit) {

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.stream.Stream;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.UrlDecoder;
@@ -18,7 +18,7 @@ import org.folio.patron.utils.Utils;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Hold;
-import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.utils.ModuleName;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -125,8 +125,8 @@ public class PatronResourceImplTest {
 
   @BeforeEach
   public void setUp(Vertx vertx, VertxTestContext context) throws Exception {
-    moduleName = PomReader.INSTANCE.getModuleName().replaceAll("_", "-");
-    moduleVersion = PomReader.INSTANCE.getVersion();
+    moduleName = ModuleName.getModuleName().replaceAll("_", "-");
+    moduleVersion = ModuleName.getModuleVersion();
     moduleId = moduleName + "-" + moduleVersion;
     logger.info("Test setup starting for " + moduleId);
 

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -325,7 +325,7 @@ public class PatronResourceImplTest {
             .end("internal server error, contact administrator");
         }
       } else if (req.path().equals("/accounts")) {
-        if (req.query().equals(String.format("limit=%d&query=%%28userId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", Integer.MAX_VALUE, goodUserId))) {
+        if (accountParametersMatch(req)) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
@@ -540,6 +540,13 @@ public class PatronResourceImplTest {
       }
     });
     server.listen(serverPort, host, context.succeeding(id -> mockOkapiStarted.flag()));
+  }
+
+  private boolean accountParametersMatch(HttpServerRequest request) {
+    final var queryString = UrlDecoder.decode(request.query());
+
+    return queryString.contains("limit=" + Integer.MAX_VALUE)
+      && queryString.contains("query=(userId==" + goodUserId + " and status.name==Open)");
   }
 
   private boolean requestsParametersMatch(HttpServerRequest request, int limit) {

--- a/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById.json
@@ -12,7 +12,7 @@
           "amount" : 100.0,
           "isoCurrencyCode" : "USD"
         },
-        "accrualDate" : "2018-01-30T00:00:01.000+0000",
+        "accrualDate" : "2018-01-30T00:00:01.000+00:00",
         "state" : "Unpaid",
         "reason" : "no item"
       },

--- a/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById.json
@@ -18,7 +18,7 @@
           "amount" : 50.0,
           "isoCurrencyCode" : "USD"
         },
-        "accrualDate" : "2018-01-31T00:00:01.000+0000",
+        "accrualDate" : "2018-01-31T00:00:01.000+00:00",
         "state" : "Paid Partially",
         "reason" : "damage - rebinding",
         "feeFineId" : "881c628b-e1c4-4711-b9d7-090af40f6a8f"
@@ -33,7 +33,7 @@
           "amount" : 25.0,
           "isoCurrencyCode" : "USD"
         },
-        "accrualDate" : "2018-04-30T00:00:01.000+0000",
+        "accrualDate" : "2018-04-30T00:00:01.000+00:00",
         "state" : "Unpaid",
         "reason" : "overdue",
         "feeFineId" : "cdf3970f-7ed2-4dae-8ae3-a8250a83a9a0"
@@ -48,7 +48,7 @@
           "amount" : 5.0,
           "isoCurrencyCode" : "USD"
         },
-        "accrualDate" : "2018-05-31T00:00:01.000+0000",
+        "accrualDate" : "2018-05-31T00:00:01.000+00:00",
         "state" : "Paid Partially",
         "reason" : "overdue",
         "feeFineId" : "cdf3970f-7ed2-4dae-8ae3-a8250a83a9a0"
@@ -63,7 +63,7 @@
           "amount" : 75.0,
           "isoCurrencyCode" : "USD"
         },
-        "accrualDate" : "2018-06-01T00:00:01.000+0000",
+        "accrualDate" : "2018-06-01T00:00:01.000+00:00",
         "state" : "Paid Partially",
         "reason" : "damage - camera",
         "feeFineId" : "ca295e87-223f-403c-9eee-a152c47bf67f"
@@ -117,8 +117,8 @@
                 "title": "Some Book About Something",
                 "author": "Some Guy; Another Guy"
             },
-            "loanDate": "2018-06-01T11:12:00.000+0000",
-            "dueDate": "2525-01-01T11:12:00.000+0000",
+            "loanDate": "2018-06-01T11:12:00.000+00:00",
+            "dueDate": "2525-01-01T11:12:00.000+00:00",
             "overdue": false
         },
         {
@@ -129,8 +129,8 @@
                 "title": "This Book Is Overdue!",
                 "author": "Tempus Fugit"
             },
-            "loanDate": "2018-03-05T22:01:00.000+0000",
-            "dueDate": "2018-04-01T09:50:00.000+0000",
+            "loanDate": "2018-03-05T22:01:00.000+00:00",
+            "dueDate": "2018-04-01T09:50:00.000+00:00",
             "overdue": true
         },
         {
@@ -141,7 +141,7 @@
                 "title": "風の谷のナウシカ",
                 "author": "宮崎 駿"
             },
-            "loanDate": "2018-06-10T16:30:00.000+0000",
+            "loanDate": "2018-06-10T16:30:00.000+00:00",
             "overdue": false
         }
     ]

--- a/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdItemByItemIdRenew.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdItemByItemIdRenew.json
@@ -6,7 +6,7 @@
         "title": "I Am Renewed!",
         "author": "McBoatface, Boaty"
     },
-    "loanDate": "2018-06-11T21:13:03.000+0000",
-    "dueDate": "2025-08-11T21:13:03.000+0000",
+    "loanDate": "2018-06-11T21:13:03.000+00:00",
+    "dueDate": "2025-08-11T21:13:03.000+00:00",
     "overdue": false
 }


### PR DESCRIPTION
Upgraded to RMB 33.x, vertx 4.1.x, and removed deprecated classes.

Significant changes to the LookupsUtils class were required to move to the vertx WebClient and the tests were impacted by several changes introduced by both the new version of RMB and the introduction of the WebClient.