### PR TITLE
MODPATRON-62: Account lookup returns wrong accrual date for fines/fees

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 4.5.0 2021-06-18
 
  * Accounts without item data attached no longer result in errors when using "includeCharges" flag (MODPATRON-59)
+ * Accounts now include correct accrual date when using the "includeCharges" flag (MODPATRON-62)
  * Requires `circulation 9.5 10.0 or 11.0` ([MODPATRON-52](https://issues.folio.org/browse/MODPATRON-52), [MODPATRON-54](https://issues.folio.org/browse/MODPATRON-54))
 
 

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -35,10 +35,13 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import static org.folio.rest.impl.HoldHelpers.*;
 
 public class PatronServicesResourceImpl implements Patron {
+  private static final Logger logger = LogManager.getLogger(PatronServicesResourceImpl.class);
 
   @Validate
   @Override
@@ -48,6 +51,7 @@ public class PatronServicesResourceImpl implements Patron {
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     try {
+
       // Look up the user to ensure that the user exists and is enabled
         LookupsUtils.getUser(id, okapiHeaders, httpClient)
         .thenAccept(this::verifyUserEnabled)
@@ -366,7 +370,7 @@ public class PatronServicesResourceImpl implements Patron {
   private Account addCharges(Account account, JsonObject body, boolean includeCharges) {
     final int totalCharges = body.getInteger(Constants.JSON_FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
     final List<Charge> charges = new ArrayList<>();
-
+    logger.info("response from accounts: " + body.toString());
     account.setTotalChargesCount(totalCharges);
     account.setCharges(charges);
 
@@ -399,7 +403,7 @@ public class PatronServicesResourceImpl implements Patron {
 
   private Charge getCharge(JsonObject chargeJson) {
     return new Charge()
-        .withAccrualDate(new DateTime(chargeJson.getString("dateCreated"), DateTimeZone.UTC).toDate())
+        .withAccrualDate(new DateTime(chargeJson.getJsonObject("metadata").getString("createdDate"), DateTimeZone.UTC).toDate())
         .withChargeAmount(new TotalCharges().withAmount(chargeJson.getDouble("remaining")).withIsoCurrencyCode("USD"))
         .withState(chargeJson.getJsonObject("paymentStatus",
             new JsonObject().put(Constants.JSON_FIELD_NAME,  "Unknown"))

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -48,7 +48,6 @@ public class PatronServicesResourceImpl implements Patron {
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     final HttpClientInterface httpClient = LookupsUtils.getHttpClient(okapiHeaders);
     try {
-
       // Look up the user to ensure that the user exists and is enabled
         LookupsUtils.getUser(id, okapiHeaders, httpClient)
         .thenAccept(this::verifyUserEnabled)

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -35,13 +35,10 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import static org.folio.rest.impl.HoldHelpers.*;
 
 public class PatronServicesResourceImpl implements Patron {
-  private static final Logger logger = LogManager.getLogger(PatronServicesResourceImpl.class);
 
   @Validate
   @Override
@@ -370,7 +367,6 @@ public class PatronServicesResourceImpl implements Patron {
   private Account addCharges(Account account, JsonObject body, boolean includeCharges) {
     final int totalCharges = body.getInteger(Constants.JSON_FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
     final List<Charge> charges = new ArrayList<>();
-    logger.info("response from accounts: " + body.toString());
     account.setTotalChargesCount(totalCharges);
     account.setCharges(charges);
 

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -576,7 +576,6 @@ public class PatronResourceImplTest {
           .extract().response();
 
     final String body = r.getBody().asString();
-    logger.info("response: " + body);
     final JsonObject json = new JsonObject(body);
     final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder + "/response_testGetPatronAccountById.json"));
 

--- a/src/test/resources/PatronServicesResourceImpl/accounts_all.json
+++ b/src/test/resources/PatronServicesResourceImpl/accounts_all.json
@@ -2,13 +2,15 @@
   "accounts": [{ 
     "amount": 100.0,
     "remaining": 100.0,
-    "dateCreated": "2018-01-30T00:00:01Z",
-    "dateUpdated": "2018-01-30T00:00:01Z",
     "status": {
       "name": "Open"
     },
     "paymentStatus": {
       "name": "Unpaid"
+    },
+    "metadata": {
+      "createdDate": "2018-01-30T00:00:01Z",
+      "updatedDate":"2018-01-30T00:00:01Z"
     },
     "feeFineType": "no item",
     "feeFineOwner": "Main library Ciculation Desk",
@@ -20,13 +22,15 @@
     "amount": 100.0,
     "remaining": 50.0,
     "accountTransaction": 1,
-    "dateCreated": "2018-01-31T00:00:01Z",
-    "dateUpdated": "2018-01-31T00:00:01Z",
     "status": {
       "name": "Open"
     },
     "paymentStatus": {
       "name": "Paid Partially"
+    },
+    "metadata":{
+      "createdDate": "2018-01-31T00:00:01Z",
+      "updatedDate": "2018-01-31T00:00:01Z"
     },
     "feeFineType": "damage - rebinding",
     "feeFineOwner": "Main library Ciculation Desk",
@@ -47,13 +51,15 @@
     "amount": 25.0,
     "remaining": 25.0,
     "accountTransaction": 2,
-    "dateCreated": "2018-04-30T00:00:01Z",
-    "dateUpdated": "2018-04-30T00:00:01Z",
     "status": {
       "name": "Open"
     },
     "paymentStatus": {
       "name": "Unpaid"
+    },
+    "metadata": {
+      "createdDate": "2018-04-30T00:00:01Z",
+      "updatedDate": "2018-04-30T00:00:01Z"
     },
     "feeFineType": "overdue",
     "feeFineOwner": "Main library Ciculation Desk",
@@ -74,13 +80,15 @@
     "amount": 10.0,
     "remaining": 5.0,
     "accountTransaction": 3,
-    "dateCreated": "2018-05-31T00:00:01Z",
-    "dateUpdated": "2018-05-31T00:00:01Z",
     "status": {
       "name": "Open"
     },
     "paymentStatus": {
       "name": "Paid Partially"
+    },
+    "metadata": {
+      "createdDate": "2018-05-31T00:00:01Z",
+      "updatedDate": "2018-05-31T00:00:01Z"
     },
     "feeFineType": "overdue",
     "feeFineOwner": "Main library Ciculation Desk",
@@ -101,13 +109,15 @@
     "amount": 500.0,
     "remaining": 75.0,
     "accountTransaction": 4,
-    "dateCreated": "2018-06-01T00:00:01Z",
-    "dateUpdated": "2018-06-01T00:00:01Z",
     "status": {
       "name": "Open"
     },
     "paymentStatus": {
       "name": "Paid Partially"
+    },
+    "metadata": {
+      "createdDate": "2018-06-01T00:00:01Z",
+      "updatedDate": "2018-06-01T00:00:01Z"
     },
     "feeFineType": "damage - camera",
     "feeFineOwner": "Main library Ciculation Desk",


### PR DESCRIPTION
The data returned from the accounts endpoint to mod-patron
does not have a "dateCreated" field at the top level.  Perhaps 
it once did and at some point the schema changed?  In any case,
the code needs to be looking for this information in the 
"metadata" jsonobject. If it does not find data where it expects, 
it looks like a later process fills in the field with the current date 
and time. The tests did not pick up on this because 
they work from a static template, and the data in that template was 
structured with the fields they expected to see.  I changed that template
to put the data where the accounts endpoint actually puts it.