### PR TITLE
Corrected missing reference for patronComments when placing PUT request

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 4.5.1 2021-06-28
+
+ * [MODPATRON-61](https://issues.folio.org/browse/MODPATRON-61): Patron Comments- Not seeing comments in response OR on FOLIO
+   request record when user creates request via opac or discovery
+
 ## 4.5.0 2021-06-18
 
  * Accounts without item data attached no longer result in errors when using "includeCharges" flag (MODPATRON-59)

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -235,7 +235,8 @@ public class PatronServicesResourceImpl implements Patron {
         .put(Constants.JSON_FIELD_INSTANCE_ID, instanceId)
         .put("requesterId", id)
         .put(Constants.JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
-        .put(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId());
+        .put(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId())
+        .put(Constants.JSON_FIELD_PATRON_COMMENTS, entity.getPatronComments());
 
     if (entity.getExpirationDate() != null) {
       holdJSON.put(Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE,

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -29,7 +29,8 @@ class RequestObjectFactory {
             .put("requestType", requestType.getValue())
             .put(Constants.JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
             .put("fulfilmentPreference", Constants.JSON_VALUE_HOLD_SHELF)
-            .put(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId());
+            .put(Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId())
+            .put(Constants.JSON_FIELD_PATRON_COMMENTS, entity.getPatronComments());
 
           if (entity.getExpirationDate() != null) {
             holdJSON.put(Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE,

--- a/src/test/resources/PatronServicesResourceImpl/request_testPostPatronAccountByIdInstanceByInstanceIdHold.json
+++ b/src/test/resources/PatronServicesResourceImpl/request_testPostPatronAccountByIdInstanceByInstanceIdHold.json
@@ -1,5 +1,6 @@
 {
   "requestDate": "2018-05-30T08:01:30Z",
   "pickupLocationId": "963396d7-c96f-4bb1-a24c-42e868a8823d",
-  "expirationDate":"3000-01-30T08:16:30Z"
+  "expirationDate": "3000-01-30T08:16:30Z",
+  "patronComments": "I need this book. Instance level comment."
 }

--- a/src/test/resources/PatronServicesResourceImpl/request_testPostPatronAccountByIdItemByItemIdHold.json
+++ b/src/test/resources/PatronServicesResourceImpl/request_testPostPatronAccountByIdItemByItemIdHold.json
@@ -1,5 +1,6 @@
 {
   "requestDate": "2018-05-30T08:01:30Z",
   "pickupLocationId": "963396d7-c96f-4bb1-a24c-42e868a8823d",
-  "expirationDate":"3000-01-30T08:16:30Z"
+  "expirationDate": "3000-01-30T08:16:30Z",
+  "patronComments": "I need this book. Item level comment."
 }


### PR DESCRIPTION
- Fixes [https://issues.folio.org/browse/MODPATRON-61](https://issues.folio.org/browse/MODPATRON-61)
- Unit test already exists, but needed sample data updated to properly validate `patronComments` field. See: https://github.com/folio-org/mod-patron/blob/b013017dda56d8e5a5627039a92fcf66091522a0/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java#L825