### PR TITLE
Use a single web client MODPATRON-66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.16</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-api-interfaces</artifactId>
       <version>${raml-module-builder.version}</version>
@@ -144,6 +150,18 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>2.25.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/folio/integration/http/HttpClientFactory.java
+++ b/src/main/java/org/folio/integration/http/HttpClientFactory.java
@@ -6,20 +6,17 @@ import java.util.concurrent.ConcurrentMap;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 
-/*
-This factory allows for a single WebClient for each instance of Vert.x
-Typically there should only be one of these in the production use of the code
-as there is only one instance of vert.x
-
-Unfortunately, the existing tests rely on creating and disposing of vert.x
-during each test which leads to the underlying vert.x instance being
-taken away underneath the production code.
-
-Meaning that if a single WebClient (dependent upon the underlying vert.x instance)
-is used, it breaks on all but the first test.
-
-Until those tests are changed this code is needed,
-even if it is potentially unnecessary in many use cases.
+/**
+ * This factory allows for a single WebClient for each instance of Vert.x
+ * Typically there should only be one of these in the production use of the code
+ * as there is only one instance of vert.x
+ * Unfortunately, the existing tests rely on creating and disposing of vert.x
+ * during each test which leads to the underlying vert.x instance being
+ * taken away underneath the production code.
+ * Meaning that if a single WebClient (dependent upon the underlying vert.x instance)
+ * is used, it breaks on all but the first test.
+ * Until those tests are changed this code is needed,
+ * even if it is potentially unnecessary in many use cases.
  */
 public class HttpClientFactory {
   private static final ConcurrentMap<Vertx, VertxOkapiHttpClient> clientMap = new ConcurrentHashMap<>();

--- a/src/main/java/org/folio/integration/http/HttpClientFactory.java
+++ b/src/main/java/org/folio/integration/http/HttpClientFactory.java
@@ -1,0 +1,38 @@
+package org.folio.integration.http;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+
+/*
+This factory allows for a single WebClient for each instance of Vert.x
+Typically there should only be one of these in the production use of the code
+as there is only one instance of vert.x
+
+Unfortunately, the existing tests rely on creating and disposing of vert.x
+during each test which leads to the underlying vert.x instance being
+taken away underneath the production code.
+
+Meaning that if a single WebClient (dependent upon the underlying vert.x instance)
+is used, it breaks on all but the first test.
+
+Until those tests are changed this code is needed,
+even if it is potentially unnecessary in many use cases.
+ */
+public class HttpClientFactory {
+  private static final ConcurrentMap<Vertx, VertxOkapiHttpClient> clientMap = new ConcurrentHashMap<>();
+
+  private HttpClientFactory() { }
+
+  public static VertxOkapiHttpClient getHttpClient(Vertx vertx) {
+    clientMap.computeIfAbsent(vertx, HttpClientFactory::createClient);
+
+    return clientMap.get(vertx);
+  }
+
+  private static VertxOkapiHttpClient createClient(Vertx v) {
+    return new VertxOkapiHttpClient(WebClient.create(v));
+  }
+}

--- a/src/main/java/org/folio/integration/http/Response.java
+++ b/src/main/java/org/folio/integration/http/Response.java
@@ -1,0 +1,15 @@
+package org.folio.integration.http;
+
+public class Response {
+  public final int statusCode;
+  public final String body;
+
+  public Response(int statusCode, String body) {
+    this.statusCode = statusCode;
+    this.body = body;
+  }
+
+  public boolean isSuccess() {
+    return statusCode >= 200 && statusCode < 300;
+  }
+}

--- a/src/main/java/org/folio/integration/http/ResponseInterpreter.java
+++ b/src/main/java/org/folio/integration/http/ResponseInterpreter.java
@@ -1,18 +1,17 @@
-package org.folio.rest.impl;
+package org.folio.integration.http;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.concurrent.CompletionException;
 
-import org.folio.integration.http.Response;
 import org.folio.patron.rest.exceptions.HttpException;
 
 import io.vertx.core.json.JsonObject;
 
-class LookupsUtils {
-  private LookupsUtils() {}
+public class ResponseInterpreter {
+  private ResponseInterpreter() {}
 
-  static JsonObject verifyAndExtractBody(Response response) {
+  public static JsonObject verifyAndExtractBody(Response response) {
     if (!response.isSuccess()) {
       throw new CompletionException(new HttpException(response.statusCode,
         response.body));

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -7,7 +7,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import io.vertx.core.MultiMap;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
@@ -17,8 +16,8 @@ import io.vertx.ext.web.client.WebClient;
 public class VertxOkapiHttpClient {
   private final WebClient client;
 
-  public VertxOkapiHttpClient(Vertx vertx) {
-    client = WebClient.create(vertx);
+  public VertxOkapiHttpClient(WebClient client) {
+    this.client = client;
   }
 
   public CompletableFuture<Response> get(String path, Map<String, String> okapiHeaders) {

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -24,13 +24,7 @@ public class VertxOkapiHttpClient {
   public CompletableFuture<Response> post(String path, JsonObject body,
     Map<String, String> okapiHeaders) {
 
-    URL url;
-
-    try {
-      url = new URL(buildUri(path, okapiHeaders));
-    } catch (MalformedURLException e) {
-      throw new CompletionException(e.getCause());
-    }
+    URL url = buildUrl(path, okapiHeaders);
 
     final var futureResponse
       = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
@@ -48,13 +42,7 @@ public class VertxOkapiHttpClient {
   public CompletableFuture<Response> put(String path, JsonObject body,
     Map<String, String> okapiHeaders) {
 
-    URL url;
-
-    try {
-      url = new URL(buildUri(path, okapiHeaders));
-    } catch (MalformedURLException e) {
-      throw new CompletionException(e.getCause());
-    }
+    URL url = buildUrl(path, okapiHeaders);
 
     final var futureResponse
       = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
@@ -69,10 +57,15 @@ public class VertxOkapiHttpClient {
       .thenCompose(this::toResponse);
   }
 
-  private static String buildUri(String path, Map<String, String> okapiHeaders) {
-    final String okapiURL = okapiHeaders.getOrDefault("X-Okapi-Url", "");
+  private URL buildUrl(String path, Map<String, String> okapiHeaders) {
+    try {
+      final var okapiURL = okapiHeaders.getOrDefault("X-Okapi-Url", "");
 
-    return okapiURL + path;
+      return new URL(okapiURL + path);
+
+    } catch (MalformedURLException e) {
+      throw new CompletionException(e.getCause());
+    }
   }
 
   private static MultiMap buildHeaders(Map<String, String> okapiHeaders) {

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -22,11 +22,19 @@ public class VertxOkapiHttpClient {
   }
 
   public CompletableFuture<Response> get(String path, Map<String, String> okapiHeaders) {
+    return get(path, Map.of(), okapiHeaders);
+  }
+
+  public CompletableFuture<Response> get(String path,
+    Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
+
     URL url = buildUrl(path, okapiHeaders);
 
     final var request = client
       .get(url.getPort(), url.getHost(), url.getPath())
       .putHeaders(buildHeaders(okapiHeaders));
+
+    queryParameters.forEach(request::addQueryParam);
 
     return request.send()
       .toCompletionStage()

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -21,6 +21,19 @@ public class VertxOkapiHttpClient {
     client = WebClient.create(vertx);
   }
 
+  public CompletableFuture<Response> get(String path, Map<String, String> okapiHeaders) {
+    URL url = buildUrl(path, okapiHeaders);
+
+    final var request = client
+      .get(url.getPort(), url.getHost(), url.getPath())
+      .putHeaders(buildHeaders(okapiHeaders));
+
+    return request.send()
+      .toCompletionStage()
+      .toCompletableFuture()
+      .thenApply(this::toResponse);
+  }
+
   public CompletableFuture<Response> post(String path, JsonObject body,
     Map<String, String> okapiHeaders) {
 

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -1,0 +1,73 @@
+package org.folio.integration.http;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+
+public class VertxOkapiHttpClient {
+  private final Vertx vertx;
+
+  public VertxOkapiHttpClient(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  public CompletableFuture<Response> post(String path,
+    JsonObject body, Map<String, String> okapiHeaders) {
+
+    URL url;
+
+    try {
+      url = new URL(buildUri(path, okapiHeaders));
+    } catch (MalformedURLException e) {
+      throw new CompletionException(e.getCause());
+    }
+
+    final var futureResponse
+      = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
+
+    final var request = WebClient.create(vertx)
+      .post(url.getPort(), url.getHost(), url.getPath())
+      .putHeaders(buildHeaders(okapiHeaders));
+
+    request.sendJson(body, futureResponse::complete);
+
+    return futureResponse
+      .thenCompose(this::toResponse);
+  }
+
+  private static String buildUri(String path, Map<String, String> okapiHeaders) {
+    final String okapiURL = okapiHeaders.getOrDefault("X-Okapi-Url", "");
+
+    return okapiURL + path;
+  }
+
+  private static MultiMap buildHeaders(Map<String, String> okapiHeaders) {
+    return MultiMap.caseInsensitiveMultiMap()
+      .addAll(okapiHeaders);
+  }
+
+  private CompletableFuture<Response> toResponse(
+    AsyncResult<HttpResponse<Buffer>> result) {
+
+    if (result.failed()) {
+      return CompletableFuture.failedFuture(result.cause());
+    }
+
+    final var response = result.result();
+
+    final var mappedResponse = new Response(response.statusCode(),
+      response.bodyAsString());
+
+    return CompletableFuture.completedFuture(mappedResponse);
+  }
+}

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -21,8 +21,8 @@ public class VertxOkapiHttpClient {
     this.vertx = vertx;
   }
 
-  public CompletableFuture<Response> post(String path,
-    JsonObject body, Map<String, String> okapiHeaders) {
+  public CompletableFuture<Response> post(String path, JsonObject body,
+    Map<String, String> okapiHeaders) {
 
     URL url;
 
@@ -37,6 +37,30 @@ public class VertxOkapiHttpClient {
 
     final var request = WebClient.create(vertx)
       .post(url.getPort(), url.getHost(), url.getPath())
+      .putHeaders(buildHeaders(okapiHeaders));
+
+    request.sendJson(body, futureResponse::complete);
+
+    return futureResponse
+      .thenCompose(this::toResponse);
+  }
+
+  public CompletableFuture<Response> put(String path, JsonObject body,
+    Map<String, String> okapiHeaders) {
+
+    URL url;
+
+    try {
+      url = new URL(buildUri(path, okapiHeaders));
+    } catch (MalformedURLException e) {
+      throw new CompletionException(e.getCause());
+    }
+
+    final var futureResponse
+      = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
+
+    final var request = WebClient.create(vertx)
+      .put(url.getPort(), url.getHost(), url.getPath())
       .putHeaders(buildHeaders(okapiHeaders));
 
     request.sendJson(body, futureResponse::complete);

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -15,10 +15,10 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 
 public class VertxOkapiHttpClient {
-  private final Vertx vertx;
+  private final WebClient client;
 
   public VertxOkapiHttpClient(Vertx vertx) {
-    this.vertx = vertx;
+    client = WebClient.create(vertx);
   }
 
   public CompletableFuture<Response> post(String path, JsonObject body,
@@ -29,7 +29,8 @@ public class VertxOkapiHttpClient {
     final var futureResponse
       = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
 
-    final var request = WebClient.create(vertx)
+
+    final var request = client
       .post(url.getPort(), url.getHost(), url.getPath())
       .putHeaders(buildHeaders(okapiHeaders));
 
@@ -47,7 +48,7 @@ public class VertxOkapiHttpClient {
     final var futureResponse
       = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
 
-    final var request = WebClient.create(vertx)
+    final var request = client
       .put(url.getPort(), url.getHost(), url.getPath())
       .putHeaders(buildHeaders(okapiHeaders));
 

--- a/src/main/java/org/folio/rest/impl/ItemRepository.java
+++ b/src/main/java/org/folio/rest/impl/ItemRepository.java
@@ -8,12 +8,14 @@ import org.folio.integration.http.VertxOkapiHttpClient;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 
 public class ItemRepository {
   private final VertxOkapiHttpClient client;
 
   public ItemRepository() {
-    client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
   }
 
   public CompletableFuture<JsonObject> getItem(String itemId,

--- a/src/main/java/org/folio/rest/impl/ItemRepository.java
+++ b/src/main/java/org/folio/rest/impl/ItemRepository.java
@@ -6,16 +6,13 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.integration.http.ResponseInterpreter;
 import org.folio.integration.http.VertxOkapiHttpClient;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.WebClient;
 
 public class ItemRepository {
   private final VertxOkapiHttpClient client;
 
-  public ItemRepository() {
-    client = new VertxOkapiHttpClient(
-      WebClient.create(Vertx.currentContext().owner()));
+  public ItemRepository(VertxOkapiHttpClient client) {
+    this.client = client;
   }
 
   public CompletableFuture<JsonObject> getItem(String itemId,

--- a/src/main/java/org/folio/rest/impl/ItemRepository.java
+++ b/src/main/java/org/folio/rest/impl/ItemRepository.java
@@ -1,0 +1,24 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.integration.http.VertxOkapiHttpClient;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+public class ItemRepository {
+  private final VertxOkapiHttpClient client;
+
+  public ItemRepository() {
+    client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+  }
+
+  public CompletableFuture<JsonObject> getItem(String itemId,
+    Map<String, String> okapiHeaders) {
+
+    return client.get("/inventory/items/" + itemId, Map.of(), okapiHeaders)
+      .thenApply(LookupsUtils::verifyAndExtractBody);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/ItemRepository.java
+++ b/src/main/java/org/folio/rest/impl/ItemRepository.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.integration.http.ResponseInterpreter;
 import org.folio.integration.http.VertxOkapiHttpClient;
 
 import io.vertx.core.Vertx;
@@ -19,6 +20,6 @@ public class ItemRepository {
     Map<String, String> okapiHeaders) {
 
     return client.get("/inventory/items/" + itemId, Map.of(), okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
+      .thenApply(ResponseInterpreter::verifyAndExtractBody);
   }
 }

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -17,10 +17,7 @@ class LookupsUtils {
   private LookupsUtils() {}
 
   static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders) {
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
-
-    return client.get("/inventory/items/" + itemId, Map.of(), okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
+    return new ItemRepository().getItem(itemId, okapiHeaders);
   }
 
   static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -71,30 +71,11 @@ class LookupsUtils {
   }
 
   public static CompletableFuture<Response> put(String path,
-                                                JsonObject body, Map<String, String> okapiHeaders) {
+    JsonObject body, Map<String, String> okapiHeaders) {
 
-    Vertx vertx = Vertx.currentContext().owner();
-    URL url;
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
 
-    try {
-      url = new URL(buildUri(path, okapiHeaders));
-    } catch (MalformedURLException e) {
-      throw new CompletionException(e.getCause());
-    }
-
-    final var futureResponse
-      = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
-
-    final var request = WebClient.create(vertx)
-      .put(url.getPort(), url.getHost(), url.getPath())
-      .putHeaders(buildHeaders(okapiHeaders));
-
-    request
-      .timeout(1000)
-      .sendJson(body, futureResponse::complete);
-
-    return futureResponse
-      .thenCompose(LookupsUtils::toResponse);
+    return client.put(path, body, okapiHeaders);
   }
 
   public static CompletableFuture<Response> get(String path,

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.integration.http.Response;
+import org.folio.integration.http.VertxOkapiHttpClient;
 import org.folio.patron.rest.exceptions.HttpException;
 
 import io.vertx.core.AsyncResult;
@@ -62,29 +63,11 @@ class LookupsUtils {
   }
 
   public static CompletableFuture<Response> post(String path,
-                                                 JsonObject body, Map<String, String> okapiHeaders) {
+    JsonObject body, Map<String, String> okapiHeaders) {
 
-    Vertx vertx = Vertx.currentContext().owner();
-    URL url;
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
 
-    try {
-      url = new URL(buildUri(path, okapiHeaders));
-    } catch (MalformedURLException e) {
-      throw new CompletionException(e.getCause());
-    }
-
-    final var futureResponse
-      = new CompletableFuture<AsyncResult<HttpResponse<Buffer>>>();
-
-    final var request = WebClient.create(vertx)
-      .post(url.getPort(), url.getHost(), url.getPath())
-      .putHeaders(buildHeaders(okapiHeaders));
-
-
-    request.sendJson(body, futureResponse::complete);
-
-    return futureResponse
-      .thenCompose(LookupsUtils::toResponse);
+    return client.post(path, body, okapiHeaders);
   }
 
   public static CompletableFuture<Response> put(String path,

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -70,12 +70,4 @@ class LookupsUtils {
 
     return client.post(path, body, okapiHeaders);
   }
-
-  public static CompletableFuture<Response> put(String path,
-    JsonObject body, Map<String, String> okapiHeaders) {
-
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
-
-    return client.put(path, body, okapiHeaders);
-  }
 }

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -16,10 +16,6 @@ import io.vertx.core.json.JsonObject;
 class LookupsUtils {
   private LookupsUtils() {}
 
-  static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders) {
-    return new ItemRepository().getItem(itemId, okapiHeaders);
-  }
-
   static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
     final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
 

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -23,27 +23,6 @@ class LookupsUtils {
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
-  static CompletableFuture<JsonObject> getRequestPolicyId(RequestTypeParameters criteria, Map<String, String> okapiHeaders) {
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
-
-    final var queryParameters = Map.of(
-      "item_type_id", criteria.getItemMaterialTypeId(),
-      "loan_type_id", criteria.getItemLoanTypeId(),
-      "patron_type_id", criteria.getPatronGroupId(),
-      "location_id", criteria.getItemLocationId());
-
-    return client.get("/circulation/rules/request-policy", queryParameters, okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
-  }
-
-  static CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders) {
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
-
-    return client.get("/request-policy-storage/request-policies/" + requestPolicyId,
-        Map.of(), okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
-  }
-
   static JsonObject verifyAndExtractBody(Response response) {
     if (!response.isSuccess()) {
       throw new CompletionException(new HttpException(response.statusCode,

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -1,10 +1,11 @@
 package org.folio.rest.impl;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.folio.integration.http.Response;
 import org.folio.integration.http.VertxOkapiHttpClient;
 import org.folio.patron.rest.exceptions.HttpException;
@@ -56,18 +57,10 @@ class LookupsUtils {
         response.body));
     }
 
-    // Parsing an emppty body to JSON causes an exception
-    if (StringUtils.isBlank(response.body)) {
+    // Parsing an empty body to JSON causes an exception
+    if (isBlank(response.body)) {
       return null;
     }
     return new JsonObject(response.body);
-  }
-
-  public static CompletableFuture<Response> post(String path,
-    JsonObject body, Map<String, String> okapiHeaders) {
-
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
-
-    return client.post(path, body, okapiHeaders);
   }
 }

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -2,26 +2,15 @@ package org.folio.rest.impl;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import org.folio.integration.http.Response;
-import org.folio.integration.http.VertxOkapiHttpClient;
 import org.folio.patron.rest.exceptions.HttpException;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
 class LookupsUtils {
   private LookupsUtils() {}
-
-  static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
-
-    return client.get("/users/" + userId, Map.of(), okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
-  }
 
   static JsonObject verifyAndExtractBody(Response response) {
     if (!response.isSuccess()) {

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.integration.http.Response;
 import org.folio.patron.rest.exceptions.HttpException;
 
 import io.vertx.core.AsyncResult;
@@ -60,8 +61,8 @@ class LookupsUtils {
     return new JsonObject(response.body);
   }
 
-  public static CompletableFuture<LookupsUtils.Response> post(String path,
-    JsonObject body, Map<String, String> okapiHeaders) {
+  public static CompletableFuture<Response> post(String path,
+                                                 JsonObject body, Map<String, String> okapiHeaders) {
 
     Vertx vertx = Vertx.currentContext().owner();
     URL url;
@@ -86,8 +87,8 @@ class LookupsUtils {
       .thenCompose(LookupsUtils::toResponse);
   }
 
-  public static CompletableFuture<LookupsUtils.Response> put(String path,
-    JsonObject body, Map<String, String> okapiHeaders) {
+  public static CompletableFuture<Response> put(String path,
+                                                JsonObject body, Map<String, String> okapiHeaders) {
 
     Vertx vertx = Vertx.currentContext().owner();
     URL url;
@@ -113,8 +114,8 @@ class LookupsUtils {
       .thenCompose(LookupsUtils::toResponse);
   }
 
-  public static CompletableFuture<LookupsUtils.Response> get(String path,
-   Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
+  public static CompletableFuture<Response> get(String path,
+                                                Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
 
     Vertx vertx = Vertx.currentContext().owner();
     URL url;
@@ -140,13 +141,13 @@ class LookupsUtils {
       .thenCompose(LookupsUtils::toResponse);
   }
 
-  public static CompletableFuture<LookupsUtils.Response> get(String path,
-    Map<String, String> okapiHeaders) {
+  public static CompletableFuture<Response> get(String path,
+                                                Map<String, String> okapiHeaders) {
 
     return get(path, Map.of(), okapiHeaders);
   }
 
-  private static CompletableFuture<LookupsUtils.Response> toResponse(
+  private static CompletableFuture<Response> toResponse(
     AsyncResult<HttpResponse<Buffer>> result) {
 
     if (result.failed()) {
@@ -170,19 +171,5 @@ class LookupsUtils {
   private static MultiMap buildHeaders(Map<String, String> okapiHeaders) {
     return MultiMap.caseInsensitiveMultiMap()
       .addAll(okapiHeaders);
-  }
-
-  public static class Response {
-    public final int statusCode;
-    public final String body;
-
-    public Response(int statusCode, String body) {
-      this.statusCode = statusCode;
-      this.body = body;
-    }
-
-    public boolean isSuccess() {
-      return statusCode >= 200 && statusCode < 300;
-    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -79,7 +79,7 @@ class LookupsUtils {
   }
 
   public static CompletableFuture<Response> get(String path,
-                                                Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
+    Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
 
     Vertx vertx = Vertx.currentContext().owner();
     URL url;
@@ -106,9 +106,11 @@ class LookupsUtils {
   }
 
   public static CompletableFuture<Response> get(String path,
-                                                Map<String, String> okapiHeaders) {
+    Map<String, String> okapiHeaders) {
 
-    return get(path, Map.of(), okapiHeaders);
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+
+    return client.get(path, okapiHeaders);
   }
 
   private static CompletableFuture<Response> toResponse(

--- a/src/main/java/org/folio/rest/impl/LookupsUtils.java
+++ b/src/main/java/org/folio/rest/impl/LookupsUtils.java
@@ -16,29 +16,37 @@ class LookupsUtils {
   private LookupsUtils() {}
 
   static CompletableFuture<JsonObject> getItem(String itemId, Map<String, String> okapiHeaders) {
-    return get("/inventory/items/" + itemId, okapiHeaders)
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+
+    return client.get("/inventory/items/" + itemId, Map.of(), okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
   static CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
-    return get("/users/" + userId, okapiHeaders)
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+
+    return client.get("/users/" + userId, Map.of(), okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
   static CompletableFuture<JsonObject> getRequestPolicyId(RequestTypeParameters criteria, Map<String, String> okapiHeaders) {
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+
     final var queryParameters = Map.of(
       "item_type_id", criteria.getItemMaterialTypeId(),
       "loan_type_id", criteria.getItemLoanTypeId(),
       "patron_type_id", criteria.getPatronGroupId(),
       "location_id", criteria.getItemLocationId());
 
-    return get("/circulation/rules/request-policy",
-        queryParameters, okapiHeaders)
+    return client.get("/circulation/rules/request-policy", queryParameters, okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
   static CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders) {
-    return get("/request-policy-storage/request-policies/" + requestPolicyId, okapiHeaders)
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+
+    return client.get("/request-policy-storage/request-policies/" + requestPolicyId,
+        Map.of(), okapiHeaders)
       .thenApply(LookupsUtils::verifyAndExtractBody);
   }
 
@@ -69,21 +77,5 @@ class LookupsUtils {
     final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
 
     return client.put(path, body, okapiHeaders);
-  }
-
-  public static CompletableFuture<Response> get(String path,
-    Map<String, String> queryParameters, Map<String, String> okapiHeaders) {
-
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
-
-    return client.get(path, queryParameters, okapiHeaders);
-  }
-
-  public static CompletableFuture<Response> get(String path,
-    Map<String, String> okapiHeaders) {
-
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
-
-    return client.get(path, Map.of(), okapiHeaders);
   }
 }

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -39,6 +39,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 
 public class PatronServicesResourceImpl implements Patron {
 
@@ -104,7 +105,8 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<JsonObject> getAccounts(String id, Map<String, String> okapiHeaders) {
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     final var queryParameters = Map.of(
       "limit", String.valueOf(getLimit(true)),
@@ -117,7 +119,8 @@ public class PatronServicesResourceImpl implements Patron {
   private CompletableFuture<JsonObject> getRequests(String id, boolean includeHolds,
     Map<String, String> okapiHeaders) {
 
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     final var queryParameters = Map.of(
       "limit", String.valueOf(getLimit(includeHolds)),
@@ -130,7 +133,8 @@ public class PatronServicesResourceImpl implements Patron {
   private CompletableFuture<JsonObject> getLoans(String id, boolean includeLoans,
     Map<String, String> okapiHeaders) {
 
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     final var queryParameters = Map.of(
       "limit", String.valueOf(getLimit(includeLoans)),
@@ -146,7 +150,8 @@ public class PatronServicesResourceImpl implements Patron {
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
 
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     final JsonObject renewalJSON = new JsonObject()
         .put(Constants.JSON_FIELD_ITEM_ID, itemId)
@@ -175,7 +180,8 @@ public class PatronServicesResourceImpl implements Patron {
       Hold entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
 
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     RequestObjectFactory requestFactory = new RequestObjectFactory(okapiHeaders);
 
@@ -219,7 +225,8 @@ public class PatronServicesResourceImpl implements Patron {
   public void postPatronAccountHoldCancelByIdAndHoldId(String id, String holdId, Hold entity, Map<String, String> okapiHeaders, Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
     final Hold[] holds = new Hold[1];
 
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     try {
       client.get("/circulation/requests/" + holdId, Map.of(), okapiHeaders)
@@ -259,7 +266,8 @@ public class PatronServicesResourceImpl implements Patron {
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler,
       Context vertxContext) {
 
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     final JsonObject holdJSON = new JsonObject()
         .put(Constants.JSON_FIELD_INSTANCE_ID, instanceId)
@@ -444,7 +452,8 @@ public class PatronServicesResourceImpl implements Patron {
   private CompletableFuture<JsonObject> getInstance(
     JsonObject item, Map<String, String> okapiHeaders) {
 
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     try {
       String cql = "holdingsRecords.id==" +

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -225,7 +225,7 @@ public class PatronServicesResourceImpl implements Patron {
         })
         .thenCompose( anUpdatedRequest -> {
           try {
-            return LookupsUtils.put("/circulation/requests/" + holdId, anUpdatedRequest, okapiHeaders);
+            return client.put("/circulation/requests/" + holdId, anUpdatedRequest, okapiHeaders);
           } catch (Exception e) {
               asyncResultHandler.handle(handleHoldCancelPOSTError(e));
               return null;

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -48,9 +48,11 @@ public class PatronServicesResourceImpl implements Patron {
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
 
+    final var userRepository = new UserRepository();
+
     try {
       // Look up the user to ensure that the user exists and is enabled
-        LookupsUtils.getUser(id, okapiHeaders)
+      userRepository.getUser(id, okapiHeaders)
         .thenAccept(this::verifyUserEnabled)
         .thenCompose(v -> {
           try {

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -42,8 +42,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 
 public class PatronServicesResourceImpl implements Patron {
-  private final VertxOkapiHttpClient httpClient = new VertxOkapiHttpClient(
-    WebClient.create(Vertx.currentContext().owner()));
+  private final VertxOkapiHttpClient httpClient;
+
+  public PatronServicesResourceImpl() {
+    httpClient = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
+  }
 
   @Validate
   @Override

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -42,7 +42,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 
 public class PatronServicesResourceImpl implements Patron {
-
   @Validate
   @Override
   public void getPatronAccountById(String id, boolean includeLoans,
@@ -50,7 +49,9 @@ public class PatronServicesResourceImpl implements Patron {
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
 
-    final var userRepository = new UserRepository();
+    final var httpClient = new VertxOkapiHttpClient(WebClient.create(vertxContext.owner()));
+
+    final var userRepository = new UserRepository(httpClient);
 
     try {
       // Look up the user to ensure that the user exists and is enabled
@@ -441,7 +442,8 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<Account> lookupItem(Charge charge, Account account, Map<String, String> okapiHeaders) {
-    final var itemRepository = new ItemRepository();
+    final var httpClient = new VertxOkapiHttpClient(WebClient.create(Vertx.currentContext().owner()));
+    final var itemRepository = new ItemRepository(httpClient);
 
     return itemRepository.getItem(charge.getItem().getItemId(), okapiHeaders)
         .thenCompose(item -> getInstance(item, okapiHeaders))

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -430,14 +430,12 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<Account> lookupItem(Charge charge, Account account, Map<String, String> okapiHeaders) {
-    return getItem(charge, okapiHeaders)
+    final var itemRepository = new ItemRepository();
+
+    return itemRepository.getItem(charge.getItem().getItemId(), okapiHeaders)
         .thenCompose(item -> getInstance(item, okapiHeaders))
         .thenApply(instance -> getItem(charge, instance))
         .thenApply(item -> updateItem(charge, item, account));
-  }
-
-  private CompletableFuture<JsonObject> getItem(Charge charge, Map<String, String> okapiHeaders) {
-    return LookupsUtils.getItem(charge.getItem().getItemId(), okapiHeaders);
   }
 
   private CompletableFuture<JsonObject> getInstance(

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -142,12 +142,15 @@ public class PatronServicesResourceImpl implements Patron {
   public void postPatronAccountItemRenewByIdAndItemId(String id, String itemId,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
+
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+
     final JsonObject renewalJSON = new JsonObject()
         .put(Constants.JSON_FIELD_ITEM_ID, itemId)
         .put(Constants.JSON_FIELD_USER_ID, id);
 
     try {
-      LookupsUtils.post("/circulation/renew-by-id", renewalJSON, okapiHeaders)
+      client.post("/circulation/renew-by-id", renewalJSON, okapiHeaders)
           .thenApply(LookupsUtils::verifyAndExtractBody)
           .thenAccept(body -> {
             final Item item = getItem(itemId, body.getJsonObject(Constants.JSON_FIELD_ITEM));
@@ -169,6 +172,8 @@ public class PatronServicesResourceImpl implements Patron {
       Hold entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler, Context vertxContext) {
 
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+
     RequestObjectFactory requestFactory = new RequestObjectFactory(okapiHeaders);
 
     requestFactory.createRequestByItem(id, itemId, entity)
@@ -188,7 +193,7 @@ public class PatronServicesResourceImpl implements Patron {
             return null;
           }
 
-          return LookupsUtils.post("/circulation/requests", holdJSON, okapiHeaders)
+          return client.post("/circulation/requests", holdJSON, okapiHeaders)
             .thenApply(LookupsUtils::verifyAndExtractBody)
             .thenAccept(body -> {
               final Item item = getItem(itemId, body.getJsonObject(Constants.JSON_FIELD_ITEM));
@@ -250,6 +255,9 @@ public class PatronServicesResourceImpl implements Patron {
       String instanceId, Hold entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler,
       Context vertxContext) {
+
+    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+
     final JsonObject holdJSON = new JsonObject()
         .put(Constants.JSON_FIELD_INSTANCE_ID, instanceId)
         .put("requesterId", id)
@@ -263,7 +271,7 @@ public class PatronServicesResourceImpl implements Patron {
     }
 
     try {
-      LookupsUtils.post("/circulation/requests/instances", holdJSON, okapiHeaders)
+      client.post("/circulation/requests/instances", holdJSON, okapiHeaders)
           .thenApply(LookupsUtils::verifyAndExtractBody)
           .thenAccept(body -> {
             final Item item = getItem(body.getString(Constants.JSON_FIELD_ITEM_ID),

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -42,12 +42,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 
 public class PatronServicesResourceImpl implements Patron {
-  private final VertxOkapiHttpClient httpClient;
-
-  public PatronServicesResourceImpl() {
-    httpClient = new VertxOkapiHttpClient(
-      WebClient.create(Vertx.currentContext().owner()));
-  }
+  private static final VertxOkapiHttpClient httpClient = new VertxOkapiHttpClient(
+    WebClient.create(Vertx.vertx()));
 
   @Validate
   @Override
@@ -426,7 +422,7 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<Account> lookupItem(Charge charge, Account account, Map<String, String> okapiHeaders) {
-    final var itemRepository = new ItemRepository(this.httpClient);
+    final var itemRepository = new ItemRepository(httpClient);
 
     return itemRepository.getItem(charge.getItem().getItemId(), okapiHeaders)
         .thenCompose(item -> getInstance(item, okapiHeaders))

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import org.folio.integration.http.ResponseInterpreter;
 import org.folio.integration.http.VertxOkapiHttpClient;
 import org.folio.patron.rest.exceptions.HttpException;
 import org.folio.patron.rest.exceptions.ModuleGeneratedHttpException;
@@ -110,7 +111,7 @@ public class PatronServicesResourceImpl implements Patron {
       "query", String.format("(userId==%s and status.name==Open)", id));
 
     return client.get("/accounts", queryParameters, okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
+      .thenApply(ResponseInterpreter::verifyAndExtractBody);
   }
 
   private CompletableFuture<JsonObject> getRequests(String id, boolean includeHolds,
@@ -123,7 +124,7 @@ public class PatronServicesResourceImpl implements Patron {
       "query", String.format("(requesterId==%s and status==Open*)", id));
 
     return client.get("/circulation/requests", queryParameters, okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
+      .thenApply(ResponseInterpreter::verifyAndExtractBody);
   }
 
   private CompletableFuture<JsonObject> getLoans(String id, boolean includeLoans,
@@ -136,7 +137,7 @@ public class PatronServicesResourceImpl implements Patron {
       "query", String.format("(userId==%s and status.name==Open)", id));
 
     return client.get("/circulation/loans", queryParameters, okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
+      .thenApply(ResponseInterpreter::verifyAndExtractBody);
   }
 
   @Validate
@@ -153,7 +154,7 @@ public class PatronServicesResourceImpl implements Patron {
 
     try {
       client.post("/circulation/renew-by-id", renewalJSON, okapiHeaders)
-          .thenApply(LookupsUtils::verifyAndExtractBody)
+          .thenApply(ResponseInterpreter::verifyAndExtractBody)
           .thenAccept(body -> {
             final Item item = getItem(itemId, body.getJsonObject(Constants.JSON_FIELD_ITEM));
             final Loan hold = getLoan(body, item);
@@ -196,7 +197,7 @@ public class PatronServicesResourceImpl implements Patron {
           }
 
           return client.post("/circulation/requests", holdJSON, okapiHeaders)
-            .thenApply(LookupsUtils::verifyAndExtractBody)
+            .thenApply(ResponseInterpreter::verifyAndExtractBody)
             .thenAccept(body -> {
               final Item item = getItem(itemId, body.getJsonObject(Constants.JSON_FIELD_ITEM));
               final Hold hold = getHold(body, item);
@@ -222,7 +223,7 @@ public class PatronServicesResourceImpl implements Patron {
 
     try {
       client.get("/circulation/requests/" + holdId, Map.of(), okapiHeaders)
-        .thenApply(LookupsUtils::verifyAndExtractBody)
+        .thenApply(ResponseInterpreter::verifyAndExtractBody)
         .thenApply( body -> {
           JsonObject itemJson = body.getJsonObject(Constants.JSON_FIELD_ITEM);
           final Item item = getItem(body.getString(Constants.JSON_FIELD_ITEM_ID), itemJson);
@@ -238,7 +239,7 @@ public class PatronServicesResourceImpl implements Patron {
               return null;
             }
         })
-        .thenApply(LookupsUtils::verifyAndExtractBody)
+        .thenApply(ResponseInterpreter::verifyAndExtractBody)
         .thenAccept(
             body -> asyncResultHandler.handle(Future.succeededFuture(
               PostPatronAccountHoldCancelByIdAndHoldIdResponse.respond200WithApplicationJson(holds[0]))))
@@ -274,7 +275,7 @@ public class PatronServicesResourceImpl implements Patron {
 
     try {
       client.post("/circulation/requests/instances", holdJSON, okapiHeaders)
-          .thenApply(LookupsUtils::verifyAndExtractBody)
+          .thenApply(ResponseInterpreter::verifyAndExtractBody)
           .thenAccept(body -> {
             final Item item = getItem(body.getString(Constants.JSON_FIELD_ITEM_ID),
                 body.getJsonObject(Constants.JSON_FIELD_ITEM));
@@ -450,7 +451,7 @@ public class PatronServicesResourceImpl implements Patron {
           StringUtil.cqlEncode(item.getString(Constants.JSON_FIELD_HOLDINGS_RECORD_ID));
 
       return client.get("/inventory/instances", Map.of("query", cql), okapiHeaders)
-          .thenApply(LookupsUtils::verifyAndExtractBody)
+          .thenApply(ResponseInterpreter::verifyAndExtractBody)
           .thenApply(instances -> instances.getJsonArray("instances").getJsonObject(0));
     } catch (Exception e) {
       throw new CompletionException(e);

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -437,7 +437,6 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<JsonObject> getItem(Charge charge, Map<String, String> okapiHeaders) {
-
     return LookupsUtils.getItem(charge.getItem().getItemId(), okapiHeaders);
   }
 

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -49,8 +49,9 @@ class RequestObjectFactory {
 
   private CompletableFuture<RequestType> getRequestType(String patronId, String itemId) {
     final var itemRepository = new ItemRepository();
+    final var userRepository = new UserRepository();
 
-    CompletableFuture<JsonObject> userFuture = LookupsUtils.getUser(patronId, okapiHeaders);
+    CompletableFuture<JsonObject> userFuture = userRepository.getUser(patronId, okapiHeaders);
     CompletableFuture<JsonObject> itemFuture = itemRepository.getItem(itemId, okapiHeaders);
 
     RequestTypeParameters requestTypeParams = new RequestTypeParameters();

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -1,15 +1,18 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.json.JsonObject;
-import org.folio.rest.jaxrs.model.Hold;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import static org.folio.rest.impl.Constants.JSON_FIELD_ID;
+import static org.folio.rest.impl.Constants.JSON_FIELD_NAME;
+import static org.folio.rest.impl.Constants.JSON_FIELD_PATRON_GROUP;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static org.folio.rest.impl.Constants.*;
+import org.folio.rest.jaxrs.model.Hold;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import io.vertx.core.json.JsonObject;
 
 class RequestObjectFactory {
   private final Map<String, String> okapiHeaders;
@@ -43,9 +46,10 @@ class RequestObjectFactory {
   }
 
   private CompletableFuture<RequestType> getRequestType(String patronId, String itemId) {
+    final var itemRepository = new ItemRepository();
 
     CompletableFuture<JsonObject> userFuture = LookupsUtils.getUser(patronId, okapiHeaders);
-    CompletableFuture<JsonObject> itemFuture = LookupsUtils.getItem(itemId, okapiHeaders);
+    CompletableFuture<JsonObject> itemFuture = itemRepository.getItem(itemId, okapiHeaders);
 
     RequestTypeParameters requestTypeParams = new RequestTypeParameters();
 

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.integration.http.ResponseInterpreter;
 import org.folio.integration.http.VertxOkapiHttpClient;
 import org.folio.rest.jaxrs.model.Hold;
 import org.joda.time.DateTime;
@@ -85,7 +86,7 @@ class RequestObjectFactory {
       "location_id", criteria.getItemLocationId());
 
     return client.get("/circulation/rules/request-policy", queryParameters, okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
+      .thenApply(ResponseInterpreter::verifyAndExtractBody);
   }
 
   private CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders) {
@@ -93,7 +94,7 @@ class RequestObjectFactory {
 
     return client.get("/request-policy-storage/request-policies/" + requestPolicyId,
         Map.of(), okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
+      .thenApply(ResponseInterpreter::verifyAndExtractBody);
   }
 
   private RequestTypeParameters createRequestPolicyIdCriteria(CompletableFuture<JsonObject> itemFuture,

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -50,8 +50,10 @@ class RequestObjectFactory {
   }
 
   private CompletableFuture<RequestType> getRequestType(String patronId, String itemId) {
-    final var itemRepository = new ItemRepository();
-    final var userRepository = new UserRepository();
+    final var httpClient = new VertxOkapiHttpClient(WebClient.create(Vertx.currentContext().owner()));
+
+    final var itemRepository = new ItemRepository(httpClient);
+    final var userRepository = new UserRepository(httpClient);
 
     CompletableFuture<JsonObject> userFuture = userRepository.getUser(patronId, okapiHeaders);
     CompletableFuture<JsonObject> itemFuture = itemRepository.getItem(itemId, okapiHeaders);

--- a/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
+++ b/src/main/java/org/folio/rest/impl/RequestObjectFactory.java
@@ -16,6 +16,7 @@ import org.joda.time.DateTimeZone;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 
 class RequestObjectFactory {
   private final Map<String, String> okapiHeaders;
@@ -77,7 +78,8 @@ class RequestObjectFactory {
   }
 
   private CompletableFuture<JsonObject> lookupRequestPolicyId(RequestTypeParameters criteria) {
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     final var queryParameters = Map.of(
       "item_type_id", criteria.getItemMaterialTypeId(),
@@ -90,7 +92,8 @@ class RequestObjectFactory {
   }
 
   private CompletableFuture<JsonObject> getRequestPolicy(String requestPolicyId, Map<String, String> okapiHeaders) {
-    final var client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    final var client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
 
     return client.get("/request-policy-storage/request-policies/" + requestPolicyId,
         Map.of(), okapiHeaders)

--- a/src/main/java/org/folio/rest/impl/UserRepository.java
+++ b/src/main/java/org/folio/rest/impl/UserRepository.java
@@ -6,16 +6,13 @@ import java.util.concurrent.CompletableFuture;
 import org.folio.integration.http.ResponseInterpreter;
 import org.folio.integration.http.VertxOkapiHttpClient;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.WebClient;
 
 public class UserRepository {
   private final VertxOkapiHttpClient client;
 
-  public UserRepository() {
-    client = new VertxOkapiHttpClient(
-      WebClient.create(Vertx.currentContext().owner()));
+  public UserRepository(VertxOkapiHttpClient client) {
+    this.client = client;
   }
 
   public CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {

--- a/src/main/java/org/folio/rest/impl/UserRepository.java
+++ b/src/main/java/org/folio/rest/impl/UserRepository.java
@@ -1,0 +1,22 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.integration.http.VertxOkapiHttpClient;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+public class UserRepository {
+  private final VertxOkapiHttpClient client;
+
+  public UserRepository() {
+    client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+  }
+
+  public CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
+    return client.get("/users/" + userId, Map.of(), okapiHeaders)
+      .thenApply(LookupsUtils::verifyAndExtractBody);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/UserRepository.java
+++ b/src/main/java/org/folio/rest/impl/UserRepository.java
@@ -8,12 +8,14 @@ import org.folio.integration.http.VertxOkapiHttpClient;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 
 public class UserRepository {
   private final VertxOkapiHttpClient client;
 
   public UserRepository() {
-    client = new VertxOkapiHttpClient(Vertx.currentContext().owner());
+    client = new VertxOkapiHttpClient(
+      WebClient.create(Vertx.currentContext().owner()));
   }
 
   public CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {

--- a/src/main/java/org/folio/rest/impl/UserRepository.java
+++ b/src/main/java/org/folio/rest/impl/UserRepository.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.folio.integration.http.ResponseInterpreter;
 import org.folio.integration.http.VertxOkapiHttpClient;
 
 import io.vertx.core.Vertx;
@@ -17,6 +18,6 @@ public class UserRepository {
 
   public CompletableFuture<JsonObject> getUser(String userId, Map<String, String> okapiHeaders) {
     return client.get("/users/" + userId, Map.of(), okapiHeaders)
-      .thenApply(LookupsUtils::verifyAndExtractBody);
+      .thenApply(ResponseInterpreter::verifyAndExtractBody);
   }
 }

--- a/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
+++ b/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
@@ -1,0 +1,117 @@
+package org.folio.integration.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.created;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.HttpStatus.HTTP_CREATED;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
+
+class VertxOkapiHttpClientTest {
+  private final WireMockServer fakeWebServer = new WireMockServer();
+  private Vertx vertx;
+
+  @BeforeEach
+  void beforeEach() {
+    fakeWebServer.start();
+
+    vertx = Vertx.vertx();
+  }
+
+  @SneakyThrows
+  @AfterEach
+  void afterEach() {
+    fakeWebServer.stop();
+
+    stopVertx();
+  }
+
+  @SneakyThrows
+  @Test
+  public void canPostWithJson() {
+    final String locationResponseHeader = "/a-different-location";
+
+    fakeWebServer.stubFor(matchingFolioHeaders(post(urlPathEqualTo("/record")))
+      .withHeader("Content-Type", equalTo("application/json"))
+      .withRequestBody(equalToJson(dummyJsonRequestBody().encodePrettily()))
+      .willReturn(created().withBody(dummyJsonResponseBody())
+        .withHeader("Content-Type", "application/json")
+        .withHeader("Location", locationResponseHeader)));
+
+    final var client = createClient();
+
+    final var postCompleted = client.post(
+      "/record", dummyJsonRequestBody(), Headers.toMap(fakeWebServer.baseUrl()));
+
+    final var response = postCompleted.get(2, SECONDS);
+
+    assertThat(response.statusCode, is(HTTP_CREATED.toInt()));
+    assertThat(asJson(response.body).getString("message"), is("hello"));
+  }
+
+  private MappingBuilder matchingFolioHeaders(MappingBuilder mappingBuilder) {
+    return mappingBuilder
+      .withHeader("X-Okapi-Url", equalTo(fakeWebServer.baseUrl()))
+      .withHeader("X-Okapi-Tenant", equalTo(Headers.tenantId))
+      .withHeader("X-Okapi-Token", equalTo(Headers.token))
+      .withHeader("X-Okapi-User-Id", equalTo(Headers.userId))
+      .withHeader("X-Okapi-Request-Id", equalTo(Headers.requestId));
+  }
+
+  private VertxOkapiHttpClient createClient() {
+    return new VertxOkapiHttpClient(vertx);
+  }
+
+  private JsonObject dummyJsonRequestBody() {
+    return new JsonObject().put("from", "James");
+  }
+
+  private String dummyJsonResponseBody() {
+    return new JsonObject().put("message", "hello")
+      .encodePrettily();
+  }
+
+  private JsonObject asJson(String body) {
+    return new JsonObject(body);
+  }
+
+  private void stopVertx() throws InterruptedException, ExecutionException, TimeoutException {
+    final var closeFuture = vertx.close();
+
+    closeFuture.toCompletionStage().toCompletableFuture().get(1, SECONDS);
+  }
+
+  private static class Headers {
+    private static final String tenantId = "test-tenant";
+    private static final String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkaWt1X2FkbWluIiwidXNlcl9pZCI6ImFhMjZjYjg4LTc2YjEtNTQ1OS1hMjM1LWZjYTRmZDI3MGMyMyIsImlhdCI6MTU3NjAxMzY3MiwidGVuYW50IjoiZGlrdSJ9.oGCb0gDIdkXGlCiECvJHgQMXD3QKKW2vTh7PPCrpds8";
+    private static final String userId = "aa26cb88-76b1-5459-a235-fca4fd270c23";
+    private static final String requestId = "test-request-id";
+
+    static Map<String, String> toMap(String okapiUrl) {
+      return Map.of(
+        "X-Okapi-Url", okapiUrl,
+        "X-Okapi-Tenant", Headers.tenantId,
+        "X-Okapi-Token", Headers.token,
+        "X-Okapi-User-Id", Headers.userId,
+        "X-Okapi-Request-Id", Headers.requestId);
+    }
+  }
+}

--- a/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
+++ b/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
@@ -31,6 +31,7 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 import lombok.SneakyThrows;
 
 class VertxOkapiHttpClientTest {
@@ -156,7 +157,7 @@ class VertxOkapiHttpClientTest {
   }
 
   private VertxOkapiHttpClient createClient() {
-    return new VertxOkapiHttpClient(vertx);
+    return new VertxOkapiHttpClient(WebClient.create(vertx));
   }
 
   private JsonObject dummyJsonRequestBody() {

--- a/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
+++ b/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
@@ -54,7 +54,7 @@ class VertxOkapiHttpClientTest {
 
   @SneakyThrows
   @Test
-  public void canGetJson() {
+  void canGetJson() {
     final var getEndpoint = matchingFolioHeaders(get(urlPathEqualTo("/record")));
 
     fakeWebServer.stubFor(getEndpoint.willReturn(ok()
@@ -76,7 +76,7 @@ class VertxOkapiHttpClientTest {
 
   @SneakyThrows
   @Test
-  public void canGetJsonUsingQueryParameters() {
+  void canGetJsonUsingQueryParameters() {
     final var getEndpoint = matchingFolioHeaders(get(urlPathEqualTo("/record")))
       .withQueryParam("first-parameter", equalTo("foo"))
       .withQueryParam("second-parameter", equalTo("bar"));
@@ -102,7 +102,7 @@ class VertxOkapiHttpClientTest {
 
   @SneakyThrows
   @Test
-  public void canPostWithJson() {
+  void canPostWithJson() {
     final var postEndpoint = matchingFolioHeaders(post(urlPathEqualTo("/record")))
       .withHeader("Content-Type", equalTo("application/json"))
       .withRequestBody(equalToJson(dummyJsonRequestBody().encodePrettily()));
@@ -126,7 +126,7 @@ class VertxOkapiHttpClientTest {
 
   @SneakyThrows
   @Test
-  public void canPutWithJson() {
+  void canPutWithJson() {
     final var putEndpoint = matchingFolioHeaders(put(urlPathEqualTo("/record")))
       .withHeader("Content-Type", equalTo("application/json"))
       .withRequestBody(equalToJson(dummyJsonRequestBody().encodePrettily()));


### PR DESCRIPTION
When [multiple web clients](https://vertx.io/docs/vertx-web-client/java/) are used they can produce memory leak like symptoms and the module can fail to take advantage of connection pooling.

In anticipation of those kinds of things being reported, this change is intended so that only a single web client is used within mod-patron.

This was considered outside of scope of the original Vert.x 4.0 upgrade work that moved the module to use web client.

In order to achieve this, the code was refactored so that all HTTP requests are made using the same client class (rather than in utility classes or other parts of the code).

This also involved introducing a factory that means that only a single WebClient is created per instance of Vert.x
Usually there would only be a single instance in production, however the current tests, start and stop vert.x meaning that using a single WebClient initialised at the beginning breaks for all but the first test.