### PR TITLE
MODPATRON-70 fix logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,17 +403,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
-        <configuration>
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>**/Log4j2Plugins.dat</exclude>
-              </excludes>
-            </filter>
-          </filters>
-        </configuration>
+	<version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -434,6 +424,7 @@
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
                     <exclude>**/log4j2.properties</exclude>
                     <exclude>**/log4j.properties</exclude>
                   </excludes>


### PR DESCRIPTION
## Purpose
Logging is broken in recent versions of this module.

See https://issues.folio.org/browse/MODPATRON-70 for details

## Approach
* Move the Log4j2Plugins.dat exclusion in the maven shade plugin to the appropriate place in pom.xml
* Not required, but update the version of the maven-shade-plugin (3.2.1 -> 3.2.4)

## Learning
https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-310