### PR TITLE
MODPATRON-77: Fee/Fines information is not returned due to a missing permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -17,6 +17,7 @@
             "accounts.collection.get",
             "inventory.items.item.get",
             "inventory.instances.item.get",
+            "inventory.instances.collection.get",
             "feefines.item.get"
           ]
         },


### PR DESCRIPTION
Backporting this fix to 5.0.2