### PR TITLE
MODPATRON-79 Add sorting of patron account info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ Microservice to allow 3rd party discovery services to perform FOLIO patron
 actions via the discovery service's UI.
 
 ## Additional information
-The endpoint GET '/patron/account/{accountId}' has optional query parameter 'sortBy' 
+The endpoint GET '/patron/account/{accountId}' has optional query parameter 'sortBy'
 that indicates the order of records within the lists of holds, charges, loans.
-The value of 'sortBy' parameter is appended as a part of a CQL query that's evaluated 
+The value of 'sortBy' parameter is appended as a part of a CQL query that's evaluated
 during separate corresponding calls to retrieve holds, charges and loans.
-If 'sortBy' is specified then it only can be used to sort one type of records, 
-and it can not be applied to all holds, charges and loans records at the same time.
-Currently, it doesn't work for loans.item object.
+Often, a given value of 'sortBy' will only work with one type of record (holds, loans,
+or charges), e.g. item.title works for holds, but not loans/charges.  The expectation is
+that when using the 'sortBy' parameter, separate calls will be made for retrieving
+holds, loans, and charges.  In cases where multiple 'include*' parameters are 'true' and
+'sortBy' is used, it's possibile (if not probable) that some of those lists will not be sorted
+as desired.
 
 Examples of requests: 
    - get holds sorted by item.title field 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,21 @@ Microservice to allow 3rd party discovery services to perform FOLIO patron
 actions via the discovery service's UI.
 
 ## Additional information
+The endpoint GET '/patron/account/{accountId}' has optional query parameter 'sortBy' 
+that indicates the order of records within the lists of holds, charges, loans.
+The value of 'sortBy' parameter is appended as a part of a CQL query that's evaluated 
+during separate corresponding calls to retrieve holds, charges and loans.
+If 'sortBy' is specified then it only can be used to sort one type of records, 
+and it can not be applied to all holds, charges and loans records at the same time.
+Currently, it doesn't work for loans.item object.
 
+Examples of requests: 
+   - get holds sorted by item.title field 
+     in ascending order: /patron/account/{accountId}?includeHold=true&&sortBy=item.title/sort.ascending
+   - get charges sorted by title field 
+     in ascending order: /patron/account/{accountId}?includeCharges=true&&sortBy=title/sort.ascending
+   - get loans sorted by loanDate field
+     in ascending order: /patron/account/{accountId}?includeCharges=true&&sortBy=loanDate/sort.ascending  
 ### Issue tracker
 
 See project [MODPATRON](https://issues.folio.org/browse/MODPATRON)

--- a/ramls/patron.raml
+++ b/ramls/patron.raml
@@ -63,7 +63,8 @@ traits:
             default: false
           sortBy:
             description: |
-              Indicates the order of records within the lists of holds, charges, loans
+              Part of CQL query, indicates the order of records within the lists of holds, charges, loans
+            example: item.title/sort.ascending
             required: false
             type: string
         responses:

--- a/ramls/patron.raml
+++ b/ramls/patron.raml
@@ -61,6 +61,11 @@ traits:
             required: false
             type: boolean
             default: false
+          sortBy:
+            description: |
+              Indicates the order of records within the lists of holds, charges, loans
+            required: false
+            type: string
         responses:
           200:
             description: Returns the user account info

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -670,14 +670,14 @@ public class PatronServicesResourceImpl implements Patron {
 
   private String buildQueryWithUserId(String userId, String sortBy) {
     if(StringUtils.isNoneBlank(sortBy)) {
-      return String.format("(userId==%s and status.name==Open and sortBy=%s)", userId, sortBy);
+      return String.format("(userId==%s and status.name==Open) sortBy %s", userId, sortBy);
     }
     return String.format("(userId==%s and status.name==Open)", userId);
   }
 
   private String buildQueryWithRequesterId(String requesterId, String sortBy) {
     if(StringUtils.isNoneBlank(sortBy)) {
-      return String.format("(requesterId==%s and status==Open* and sortBy=%s)", requesterId, sortBy);
+      return String.format("(requesterId==%s and status==Open*) sortBy %s", requesterId, sortBy);
     }
     return String.format("(requesterId==%s and status==Open*)", requesterId);
   }

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -587,7 +587,6 @@ public class PatronResourceImplTest {
       && queryString.contains(String.format("query=(requesterId==%s and status==Open*)", goodUserId));
   }
 
-
   private boolean requestsParametersWithSortByMatchMatch(HttpServerRequest request, int limit) {
     final var queryString = UrlDecoder.decode(request.query());
 

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -577,7 +577,7 @@ public class PatronResourceImplTest {
 
     return queryString.contains("limit=" + Integer.MAX_VALUE)
       && queryString
-      .contains(String.format("query=(userId==%s and status.name==Open and sortBy=%s)", goodUserId, sortByParam));
+      .contains(String.format("query=(userId==%s and status.name==Open) sortBy %s", goodUserId, sortByParam));
   }
 
   private boolean requestsParametersMatch(HttpServerRequest request, int limit) {
@@ -593,7 +593,7 @@ public class PatronResourceImplTest {
 
     return queryString.contains("limit=" + limit)
       && queryString
-      .contains(String.format("query=(requesterId==%s and status==Open* and sortBy=%s)", goodUserId, sortByParam));
+      .contains(String.format("query=(requesterId==%s and status==Open*) sortBy %s", goodUserId, sortByParam));
   }
 
   private Boolean isInactiveUser(HttpServerRequest request) {
@@ -612,7 +612,7 @@ public class PatronResourceImplTest {
     final var queryString = UrlDecoder.decode(request.query());
 
     return queryString.contains("limit=" + limit) && queryString
-      .contains(String.format("query=(userId==%s and status.name==Open and sortBy=%s)", goodUserId, sortByParam));
+      .contains(String.format("query=(userId==%s and status.name==Open) sortBy %s", goodUserId, sortByParam));
   }
 
   private boolean rulesParametersMatch(HttpServerRequest request, String materialTypeId) {

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -48,6 +48,7 @@ import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
 public class PatronResourceImplTest {
+
   private final Logger logger = LogManager.getLogger();
 
   private String moduleName;
@@ -117,6 +118,7 @@ public class PatronResourceImplTest {
   private final String intransitItemId = "32e5757d-6566-466e-b69d-994eb33d2c98";
   private static final String availableItemId = "32e5757d-6566-466e-b69d-994eb33d2b62";
   private static final String checkedoutItemId = "32e5757d-6566-466e-b69d-994eb33d2b73";
+  private static final String sortByParam = "item.title/sort.ascending";
 
   static {
     System.setProperty("vertx.logger-delegate-factory-class-name",
@@ -181,6 +183,11 @@ public class PatronResourceImplTest {
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile(mockDataFolder + "/loans_totals.json"));
+        } else if (loansParametersWithSortByMatch(req, Integer.MAX_VALUE)) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile(mockDataFolder + "/loans_all_active_and_sorted.json"));
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
@@ -244,6 +251,11 @@ public class PatronResourceImplTest {
               .setStatusCode(200)
               .putHeader("content-type", "application/json")
               .end(readMockFile(mockDataFolder + "/holds_totals.json"));
+          } else if (requestsParametersWithSortByMatchMatch(req, Integer.MAX_VALUE)) {
+            req.response()
+              .setStatusCode(200)
+              .putHeader("content-type", "application/json")
+              .end(readMockFile(mockDataFolder + "/holds_all_active_and_sorted.json"));
           } else {
             req.response().setStatusCode(500).end("Unexpected call: " + req.path());
           }
@@ -348,6 +360,11 @@ public class PatronResourceImplTest {
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile(mockDataFolder + "/accounts_all_active.json"));
+        } else if (accountParametersWithSortByMatch(req)) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile(mockDataFolder + "/accounts_all_active_and_sorted.json"));
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
@@ -552,16 +569,33 @@ public class PatronResourceImplTest {
     final var queryString = UrlDecoder.decode(request.query());
 
     return queryString.contains("limit=" + Integer.MAX_VALUE)
-      && queryString.contains("query=(userId==" + goodUserId + " and status.name==Open)");
+      && queryString.contains(String.format("query=(userId==%s and status.name==Open)", goodUserId));
+  }
+
+  private boolean accountParametersWithSortByMatch(HttpServerRequest request) {
+    final var queryString = UrlDecoder.decode(request.query());
+
+    return queryString.contains("limit=" + Integer.MAX_VALUE)
+      && queryString
+      .contains(String.format("query=(userId==%s and status.name==Open and sortBy=%s)", goodUserId, sortByParam));
   }
 
   private boolean requestsParametersMatch(HttpServerRequest request, int limit) {
     final var queryString = UrlDecoder.decode(request.query());
 
     return queryString.contains("limit=" + limit)
-      && queryString.contains("query=(requesterId==" + goodUserId + " and status==Open*)");
+      && queryString.contains(String.format("query=(requesterId==%s and status==Open*)", goodUserId));
   }
-  
+
+
+  private boolean requestsParametersWithSortByMatchMatch(HttpServerRequest request, int limit) {
+    final var queryString = UrlDecoder.decode(request.query());
+
+    return queryString.contains("limit=" + limit)
+      && queryString
+      .contains(String.format("query=(requesterId==%s and status==Open* and sortBy=%s)", goodUserId, sortByParam));
+  }
+
   private Boolean isInactiveUser(HttpServerRequest request) {
     final var queryString = UrlDecoder.decode(request.query());
     return queryString.contains(inactiveUserId);
@@ -571,7 +605,14 @@ public class PatronResourceImplTest {
     final var queryString = UrlDecoder.decode(request.query());
 
     return queryString.contains("limit=" + limit)
-      && queryString.contains("query=(userId==" + goodUserId + " and status.name==Open)");
+      && queryString.contains(String.format("query=(userId==%s and status.name==Open)", goodUserId));
+  }
+
+  private boolean loansParametersWithSortByMatch(HttpServerRequest request, int limit) {
+    final var queryString = UrlDecoder.decode(request.query());
+
+    return queryString.contains("limit=" + limit) && queryString
+      .contains(String.format("query=(userId==%s and status.name==Open and sortBy=%s)", goodUserId, sortByParam));
   }
 
   private boolean rulesParametersMatch(HttpServerRequest request, String materialTypeId) {
@@ -614,68 +655,40 @@ public class PatronResourceImplTest {
     final JsonObject json = new JsonObject(body);
     final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder + "/response_testGetPatronAccountById.json"));
 
-    assertEquals(3, json.getInteger("totalLoans"));
-    assertEquals(3, json.getJsonArray("loans").size());
+    verifyAccount(json, expectedJson);
 
-    assertEquals(3, json.getInteger("totalHolds"));
-    assertEquals(3, json.getJsonArray("holds").size());
+    // Test done
+    logger.info("Test done");
+  }
 
-    JsonObject money = json.getJsonObject("totalCharges");
-    assertEquals(255.0, money.getDouble("amount"));
-    assertEquals("USD", money.getString("isoCurrencyCode"));
-    assertEquals(5, json.getInteger("totalChargesCount"));
-    assertEquals(5, json.getJsonArray("charges").size());
+  @Test
+  public final void testGetPatronAccountByIdSortedByItemId() {
+    logger.info("Testing for successful patron services account retrieval by id and sorted by item title");
 
-    for (int i = 0; i < 5; i++) {
-      final JsonObject jo = json.getJsonArray("charges").getJsonObject(i);
+    final Response r = given()
+        .log().all()
+        .header(tenantHeader)
+        .header(urlHeader)
+        .header(contentTypeHeader)
+        .pathParam("accountId", goodUserId)
+        .queryParam("includeLoans", "true")
+        .queryParam("includeHolds", "true")
+        .queryParam("includeCharges", "true")
+        .queryParam("sortBy", sortByParam)
+      .when()
+        .get(accountPath)
+      .then()
+        .log().all()
+        .contentType(ContentType.JSON)
+        .statusCode(200)
+        .extract().response();
 
-      boolean found = false;
-      for (int j = 0; j < 5; j++) {
-        final JsonObject expectedJO = expectedJson.getJsonArray("charges").getJsonObject(j);
-        if (verifyCharge(expectedJO, jo)) {
-          found = true;
-          break;
-        }
-      }
+    final String body = r.getBody().asString();
+    final JsonObject json = new JsonObject(body);
+    final JsonObject expectedJson = new JsonObject(
+      readMockFile(mockDataFolder + "/response_testGetPatronAccountById_sortedByItemTitle.json"));
 
-      if (found == false) {
-        fail("Unexpected charge: " + jo.toString());
-      }
-    }
-
-    for (int i = 0; i < 3; i++) {
-      final JsonObject jo = json.getJsonArray("holds").getJsonObject(i);
-
-      boolean found = false;
-      for (int j = 0; j < 3; j++) {
-        final JsonObject expectedJO = expectedJson.getJsonArray("holds").getJsonObject(j);
-        if (verifyHold(expectedJO, jo)) {
-          found = true;
-          break;
-        }
-      }
-
-      if (found == false) {
-        fail("Unexpected id: " + jo.getString("requestId"));
-      }
-    }
-
-    for (int i = 0; i < 3; i++) {
-      final JsonObject jo = json.getJsonArray("loans").getJsonObject(i);
-
-      boolean found = false;
-      for (int j = 0; j < 3; j++) {
-        final JsonObject expectedJO = expectedJson.getJsonArray("loans").getJsonObject(j);
-        if (verifyLoan(expectedJO, jo)) {
-          found = true;
-          break;
-        }
-      }
-
-      if (found == false) {
-        fail("Unexpected loan: " + jo.toString());
-      }
-    }
+    verifyAccount(json, expectedJson);
 
     // Test done
     logger.info("Test done");
@@ -736,13 +749,13 @@ public class PatronResourceImplTest {
 
     final String body = r.getBody().asString();
     final JsonObject json = new JsonObject(body);
-  
+
     assertEquals(1, json.getInteger("totalLoans"));
     assertEquals(0, json.getJsonArray("loans").size());
-  
+
     assertEquals(0, json.getInteger("totalHolds"));
     assertEquals(0, json.getJsonArray("holds").size());
-  
+
     final JsonObject money = json.getJsonObject("totalCharges");
     assertEquals(100.0, money.getDouble("amount"));
     assertEquals("USD", money.getString("isoCurrencyCode"));
@@ -1310,6 +1323,71 @@ public class PatronResourceImplTest {
     }
 
     return false;
+  }
+
+  private void verifyAccount(JsonObject actualAccountJson, JsonObject expectedAccountJson) {
+    assertEquals(3, actualAccountJson.getInteger("totalLoans"));
+    assertEquals(3, actualAccountJson.getJsonArray("loans").size());
+
+    assertEquals(3, actualAccountJson.getInteger("totalHolds"));
+    assertEquals(3, actualAccountJson.getJsonArray("holds").size());
+
+    JsonObject money = actualAccountJson.getJsonObject("totalCharges");
+    assertEquals(255.0, money.getDouble("amount"));
+    assertEquals("USD", money.getString("isoCurrencyCode"));
+    assertEquals(5, actualAccountJson.getInteger("totalChargesCount"));
+    assertEquals(5, actualAccountJson.getJsonArray("charges").size());
+
+    for (int i = 0; i < 5; i++) {
+      final JsonObject jo = actualAccountJson.getJsonArray("charges").getJsonObject(i);
+
+      boolean found = false;
+      for (int j = 0; j < 5; j++) {
+        final JsonObject expectedJO = expectedAccountJson.getJsonArray("charges").getJsonObject(j);
+        if (verifyCharge(expectedJO, jo)) {
+          found = true;
+          break;
+        }
+      }
+
+      if (found == false) {
+        fail("Unexpected charge: " + jo.toString());
+      }
+    }
+
+    for (int i = 0; i < 3; i++) {
+      final JsonObject jo = actualAccountJson.getJsonArray("holds").getJsonObject(i);
+
+      boolean found = false;
+      for (int j = 0; j < 3; j++) {
+        final JsonObject expectedJO = expectedAccountJson.getJsonArray("holds").getJsonObject(j);
+        if (verifyHold(expectedJO, jo)) {
+          found = true;
+          break;
+        }
+      }
+
+      if (found == false) {
+        fail("Unexpected id: " + jo.getString("requestId"));
+      }
+    }
+
+    for (int i = 0; i < 3; i++) {
+      final JsonObject jo = actualAccountJson.getJsonArray("loans").getJsonObject(i);
+
+      boolean found = false;
+      for (int j = 0; j < 3; j++) {
+        final JsonObject expectedJO = expectedAccountJson.getJsonArray("loans").getJsonObject(j);
+        if (verifyLoan(expectedJO, jo)) {
+          found = true;
+          break;
+        }
+      }
+
+      if (found == false) {
+        fail("Unexpected loan: " + jo.toString());
+      }
+    }
   }
 
   private void verifyAmount(JsonObject expectedAmount, JsonObject actualAmount) {

--- a/src/test/resources/PatronServicesResourceImpl/accounts_all_active_and_sorted.json
+++ b/src/test/resources/PatronServicesResourceImpl/accounts_all_active_and_sorted.json
@@ -1,0 +1,139 @@
+{
+  "accounts": [{
+    "amount": 100.0,
+    "remaining": 100.0,
+    "status": {
+      "name": "Open"
+    },
+    "paymentStatus": {
+      "name": "Unpaid"
+    },
+    "metadata": {
+      "createdDate": "2018-01-30T00:00:01Z",
+      "updatedDate":"2018-01-30T00:00:01Z"
+    },
+    "feeFineType": "no item",
+    "feeFineOwner": "Main library Ciculation Desk",
+    "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+    "feeFineId": "771b629b-e2c4-4711-b9d7-091af40f6b8b",
+    "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8",
+    "id": "749cf599-3a33-474e-8fa4-268a5b66fddf"
+  },{
+    "amount": 10.0,
+    "remaining": 5.0,
+    "accountTransaction": 3,
+    "status": {
+      "name": "Open"
+    },
+    "paymentStatus": {
+      "name": "Paid Partially"
+    },
+    "metadata": {
+      "createdDate": "2018-05-31T00:00:01Z",
+      "updatedDate": "2018-05-31T00:00:01Z"
+    },
+    "feeFineType": "overdue",
+    "feeFineOwner": "Main library Ciculation Desk",
+    "title": "風の谷のナウシカ",
+    "callNumber": "Book 3 call number",
+    "barcode": "1234567892",
+    "materialType": "book",
+    "itemStatus": {"name": "Checked out"},
+    "location": "Main library",
+    "loanId": "947b9387-892a-4d60-a854-a6395d0f03f0",
+    "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+    "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+    "itemId": "688be386-5522-4505-ad8e-60d84385d43f",
+    "feeFineId": "cdf3970f-7ed2-4dae-8ae3-a8250a83a9a0",
+    "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8",
+    "id": "749bf599-3a31-494e-9fa4-268a5b67fdde"
+  },{
+    "amount": 500.0,
+    "remaining": 75.0,
+    "accountTransaction": 4,
+    "status": {
+      "name": "Open"
+    },
+    "paymentStatus": {
+      "name": "Paid Partially"
+    },
+    "metadata": {
+      "createdDate": "2018-06-01T00:00:01Z",
+      "updatedDate": "2018-06-01T00:00:01Z"
+    },
+    "feeFineType": "damage - camera",
+    "feeFineOwner": "Main library Ciculation Desk",
+    "title": "Awesome Digital Camera",
+    "callNumber": "Digital camera call number",
+    "barcode": "1234567893",
+    "materialType": "unspecified",
+    "itemStatus": {"name": "Checked out"},
+    "location": "Main library",
+    "loanId": "fae5c8cc-aec8-408e-8e2f-eeb8377fba27",
+    "materialTypeId": "71fbd940-1027-40a6-8a48-49b44d795e46",
+    "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+    "itemId": "240e521c-12df-4744-a5ab-313862ec1752",
+    "feeFineId": "ca295e87-223f-403c-9eee-a152c47bf67f",
+    "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8",
+    "id": "749bf599-3a31-494e-9fa4-268a5b67fdde"
+  },{
+    "amount": 100.0,
+    "remaining": 50.0,
+    "accountTransaction": 1,
+    "status": {
+      "name": "Open"
+    },
+    "paymentStatus": {
+      "name": "Paid Partially"
+    },
+    "metadata":{
+      "createdDate": "2018-01-31T00:00:01Z",
+      "updatedDate": "2018-01-31T00:00:01Z"
+    },
+    "feeFineType": "damage - rebinding",
+    "feeFineOwner": "Main library Ciculation Desk",
+    "title": "Some Book About Something",
+    "callNumber": "Book 1 call number",
+    "barcode": "1234567890",
+    "materialType": "book",
+    "itemStatus": {"name": "Checked out"},
+    "location": "Main library",
+    "loanId": "9a171a89-baca-4f1a-b2c4-d7253854864e",
+    "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+    "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+    "itemId": "7d9dfe70-0158-489d-a7ed-2789eac277b3",
+    "feeFineId": "881c628b-e1c4-4711-b9d7-090af40f6a8f",
+    "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8",
+    "id": "749bf599-3a31-494e-9fa4-268a5b67fdde"
+  },{
+    "amount": 25.0,
+    "remaining": 25.0,
+    "accountTransaction": 2,
+    "status": {
+      "name": "Open"
+    },
+    "paymentStatus": {
+      "name": "Unpaid"
+    },
+    "metadata": {
+      "createdDate": "2018-04-30T00:00:01Z",
+      "updatedDate": "2018-04-30T00:00:01Z"
+    },
+    "feeFineType": "overdue",
+    "feeFineOwner": "Main library Ciculation Desk",
+    "title": "This Book Is Overdue",
+    "callNumber": "Book 2 call number",
+    "barcode": "1234567891",
+    "materialType": "book",
+    "itemStatus": {"name": "Checked out"},
+    "location": "Main library",
+    "loanId": "76d957eb-df99-41b8-a495-d03541d079fb",
+    "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+    "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+    "itemId": "7d4bfd9c-dc46-46a1-89bd-160c61fe46d8",
+    "feeFineId": "cdf3970f-7ed2-4dae-8ae3-a8250a83a9a0",
+    "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8",
+    "id": "749bf599-3a31-494e-9fa4-268a5b67fdde"
+  } ],
+  "totalRecords": 5
+}

--- a/src/test/resources/PatronServicesResourceImpl/holds_all_active_and_sorted.json
+++ b/src/test/resources/PatronServicesResourceImpl/holds_all_active_and_sorted.json
@@ -1,0 +1,61 @@
+{
+  "requests": [
+    {
+      "id": "24a5de73-859b-491f-825d-a96ea47297fb",
+      "requesterId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+      "itemId": "dbdcb2b5-b302-4254-a55d-3c429794a4bb",
+      "requestType": "Hold",
+      "requestDate": "2018-05-01T05:01:15Z",
+      "fulfilmentPreference": "Hold Shelf",
+      "status": "Open - Awaiting pickup",
+      "position": 3,
+      "item" :{
+        "title": "Hold On",
+        "instanceId": "0b559683-9059-4b6d-bb6a-c55aa3518df3",
+        "contributors": [
+          {"name": "Jon Anderson"},
+          {"name": "Trevor Rabin"},
+          {"name": "Chris Squire"}
+        ]
+      }
+    },
+    {
+      "id": "69273dca-eacf-4225-9065-c05bbffc9d7d",
+      "requesterId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+      "itemId": "c3cfcb01-4f5d-40df-856a-c86ffe8f2d5f",
+      "requestType": "Hold",
+      "requestDate": "2018-04-01T15:22:12Z",
+      "fulfilmentPreference": "Hold Shelf",
+      "status": "Open - Not yet filled",
+      "requestExpirationDate": "2020-01-31T15:22:12Z",
+      "position": 5,
+      "item" :{
+        "title": "Hold On, I'm Comin'",
+        "instanceId": "4bb0fffc-fe55-4445-819d-9bc5b8cd47ef",
+        "contributors": [
+          {"name": "Isaac Hayes"},
+          {"name": "David Porter"}
+        ]
+      }
+    },
+    {
+      "id": "8bbac557-d66f-4571-bbbf-47a107cc1589",
+      "requesterId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+      "itemId": "26670295-716a-4f84-8f65-2ef31707c017",
+      "requestType": "Hold",
+      "requestDate": "2018-06-02T08:16:30Z",
+      "fulfilmentPreference": "Hold Shelf",
+      "status": "Open - Not yet filled",
+      "position": 1,
+      "item" :{
+        "title": "I Want to Hold Your Hand",
+        "instanceId": "255f82f3-5b1b-4239-93e4-ec6acf03ad9d",
+        "contributors": [
+          {"name": "John Lennon"},
+          {"name": "Paul McCartney"}
+        ]
+      }
+    }
+  ],
+  "totalRecords": 3
+}

--- a/src/test/resources/PatronServicesResourceImpl/loans_all_active_and_sorted.json
+++ b/src/test/resources/PatronServicesResourceImpl/loans_all_active_and_sorted.json
@@ -1,0 +1,50 @@
+{
+  "loans": [
+    {
+      "id": "947b9387-892a-4d60-a854-a6395d0f03f0",
+      "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+      "itemId": "688be386-5522-4505-ad8e-60d84385d43f",
+      "loanDate": "2018-06-10T16:30:00.000Z",
+      "action": "checkedout",
+      "item": {
+        "instanceId": "f3482bed-a7e9-4f07-beb0-ebd693331350",
+        "title": "風の谷のナウシカ",
+        "contributors" : [
+          {"name": "宮崎 駿"}
+        ]
+      }
+    },
+    {
+      "id": "9a171a89-baca-4f1a-b2c4-d7253854864e",
+      "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+      "itemId": "7d9dfe70-0158-489d-a7ed-2789eac277b3",
+      "loanDate": "2018-06-01T11:12:00.000Z",
+      "dueDate": "2525-01-01T11:12:00.000Z",
+      "action": "checkedout",
+      "item": {
+        "instanceId": "6e024cd5-c19a-4fe0-a2cd-64ce5814c694",
+        "title": "Some Book About Something",
+        "contributors" : [
+          {"name": "Some Guy"},
+          {"name": "Another Guy"}
+        ]
+      }
+    },
+    {
+      "id": "76d957eb-df99-41b8-a495-d03541d079fb",
+      "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+      "itemId": "7d4bfd9c-dc46-46a1-89bd-160c61fe46d8",
+      "loanDate": "2018-03-05T22:01:00.000Z",
+      "dueDate": "2018-04-01T09:50:00.000Z",
+      "action": "checkedout",
+      "item": {
+        "instanceId": "b3f5ef6d-2309-4935-858d-870cd7801632",
+        "title": "This Book Is Overdue!",
+        "contributors" : [
+          {"name": "Tempus Fugit"}
+        ]
+      }
+    }
+  ],
+  "totalRecords": 3
+}

--- a/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById_sortedByItemTitle.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountById_sortedByItemTitle.json
@@ -1,0 +1,153 @@
+{
+    "totalCharges": {
+        "amount": 255.0,
+        "isoCurrencyCode": "USD"
+    },
+    "totalChargesCount": 5,
+    "totalLoans": 3,
+    "totalHolds": 3,
+    "charges": [
+      {
+        "chargeAmount" : {
+          "amount" : 100.0,
+          "isoCurrencyCode" : "USD"
+        },
+        "accrualDate" : "2018-01-30T00:00:01.000+00:00",
+        "state" : "Unpaid",
+        "reason" : "no item"
+      }, {
+        "item" : {
+          "instanceId" : "f3482bed-a7e9-4f07-beb0-ebd693331350",
+          "itemId" : "688be386-5522-4505-ad8e-60d84385d43f",
+          "title" : "風の谷のナウシカ",
+          "author" : "宮崎 駿"
+        },
+        "chargeAmount" : {
+          "amount" : 5.0,
+          "isoCurrencyCode" : "USD"
+        },
+        "accrualDate" : "2018-05-31T00:00:01.000+00:00",
+        "state" : "Paid Partially",
+        "reason" : "overdue"
+      }, {
+        "item" : {
+          "instanceId" : "c394b514-9fd0-496d-ab9a-aec777facc1b",
+          "itemId" : "240e521c-12df-4744-a5ab-313862ec1752",
+          "title" : "Awesome Digital Camera",
+          "author" : "Canon"
+        },
+        "chargeAmount" : {
+          "amount" : 75.0,
+          "isoCurrencyCode" : "USD"
+        },
+        "accrualDate" : "2018-06-01T00:00:01.000+00:00",
+        "state" : "Paid Partially",
+        "reason" : "damage - camera",
+        "feeFineId" : "ca295e87-223f-403c-9eee-a152c47bf67f"
+      }, {
+        "item" : {
+          "instanceId" : "6e024cd5-c19a-4fe0-a2cd-64ce5814c694",
+          "itemId" : "7d9dfe70-0158-489d-a7ed-2789eac277b3",
+          "title" : "Some Book About Something",
+          "author" : "Some Guy; Another Guy"
+        },
+        "chargeAmount" : {
+          "amount" : 50.0,
+          "isoCurrencyCode" : "USD"
+        },
+        "accrualDate" : "2018-01-31T00:00:01.000+00:00",
+        "state" : "Paid Partially",
+        "reason" : "damage - rebinding"
+      }, {
+        "item" : {
+          "instanceId" : "75d0799a-66d8-46cf-a7e3-ed7390425112",
+          "itemId" : "7d4bfd9c-dc46-46a1-89bd-160c61fe46d8",
+          "title" : "This Book Is Overdue!",
+          "author" : "Tempus Fugit"
+        },
+        "chargeAmount" : {
+          "amount" : 25.0,
+          "isoCurrencyCode" : "USD"
+        },
+        "accrualDate" : "2018-04-30T00:00:01.000+00:00",
+        "state" : "Unpaid",
+        "reason" : "overdue"
+      }
+    ],
+    "holds": [
+        {
+          "requestId": "24a5de73-859b-491f-825d-a96ea47297fb",
+          "item": {
+            "instanceId": "0b559683-9059-4b6d-bb6a-c55aa3518df3",
+            "itemId": "dbdcb2b5-b302-4254-a55d-3c429794a4bb",
+            "title": "Hold On",
+            "author": "Jon Anderson; Trevor Rabin; Chris Squire"
+          },
+          "queuePosition": 3,
+          "fulfillmentPreference": "Hold Shelf",
+          "status": "Open - Awaiting pickup"
+        },
+        {
+          "requestId": "69273dca-eacf-4225-9065-c05bbffc9d7d",
+          "item": {
+            "instanceId": "4bb0fffc-fe55-4445-819d-9bc5b8cd47ef",
+            "itemId": "c3cfcb01-4f5d-40df-856a-c86ffe8f2d5f",
+            "title": "Hold On, I'm Comin'",
+            "author": "Isaac Hayes; David Porter"
+          },
+          "queuePosition": 5,
+          "expirationDate": "2020-01-31T15:22:12Z",
+          "fulfillmentPreference": "Hold Shelf",
+          "status": "Open - Not yet filled"
+        },
+        {
+            "requestId": "8bbac557-d66f-4571-bbbf-47a107cc1589",
+            "item": {
+                "instanceId": "255f82f3-5b1b-4239-93e4-ec6acf03ad9d",
+                "itemId": "26670295-716a-4f84-8f65-2ef31707c017",
+                "title": "I Want to Hold Your Hand",
+                "author": "John Lennon; Paul McCartney"
+            },
+            "queuePosition": 1,
+            "fulfillmentPreference": "Hold Shelf",
+            "status": "Open - Not yet filled"
+        }
+    ],
+    "loans": [
+        {
+          "id": "947b9387-892a-4d60-a854-a6395d0f03f0",
+          "item": {
+            "instanceId": "f3482bed-a7e9-4f07-beb0-ebd693331350",
+            "itemId": "688be386-5522-4505-ad8e-60d84385d43f",
+            "title": "風の谷のナウシカ",
+            "author": "宮崎 駿"
+          },
+          "loanDate": "2018-06-10T16:30:00.000+00:00",
+          "overdue": false
+        },
+        {
+            "id": "9a171a89-baca-4f1a-b2c4-d7253854864e",
+            "item": {
+                "instanceId": "6e024cd5-c19a-4fe0-a2cd-64ce5814c694",
+                "itemId": "7d9dfe70-0158-489d-a7ed-2789eac277b3",
+                "title": "Some Book About Something",
+                "author": "Some Guy; Another Guy"
+            },
+            "loanDate": "2018-06-01T11:12:00.000+00:00",
+            "dueDate": "2525-01-01T11:12:00.000+00:00",
+            "overdue": false
+        },
+        {
+            "id": "76d957eb-df99-41b8-a495-d03541d079fb",
+            "item": {
+                "instanceId": "b3f5ef6d-2309-4935-858d-870cd7801632",
+                "itemId": "7d4bfd9c-dc46-46a1-89bd-160c61fe46d8",
+                "title": "This Book Is Overdue!",
+                "author": "Tempus Fugit"
+            },
+            "loanDate": "2018-03-05T22:01:00.000+00:00",
+            "dueDate": "2018-04-01T09:50:00.000+00:00",
+            "overdue": true
+        }
+    ]
+}


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODPATRON-79

Add new sortBy parameter for GET /patron/account/{id} endpoint to support for sorting the lists of {holds, loans, charges} in  account info responses. 
## Approach
1) Update GET /patron/account/{id} endpoint in patron.raml with sortBy query parameter
2) Update PatronServicesResourceImpl to append sortBy value to query CQL expression when retrieve loans (GET /circulation/loans), charges (GET /accounts) and holds (GET /circulation/requests)
3) Update unit tests 
