### PR TITLE
MODPATRON-80 Support paging of patron account info

### DIFF
--- a/ramls/patron.raml
+++ b/ramls/patron.raml
@@ -80,7 +80,7 @@ traits:
             type: integer
             required: false
             example: 10
-            default: 0
+            default: 2147483647
             minimum: 0
             maximum: 2147483647
         responses:

--- a/ramls/patron.raml
+++ b/ramls/patron.raml
@@ -67,6 +67,22 @@ traits:
             example: item.title/sort.ascending
             required: false
             type: string
+          offset:
+            description: Skip over a number of elements by specifying an offset value for the query
+            type: integer
+            required: false
+            example: 0
+            default: 0
+            minimum: 0
+            maximum: 2147483647
+          limit:
+            description: Limit the number of elements returned in the response
+            type: integer
+            required: false
+            example: 10
+            default: 0
+            minimum: 0
+            maximum: 2147483647
         responses:
           200:
             description: Returns the user account info

--- a/ramls/patron.raml
+++ b/ramls/patron.raml
@@ -81,7 +81,6 @@ traits:
             required: false
             example: 10
             default: 2147483647
-            minimum: 0
             maximum: 2147483647
         responses:
           200:

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -477,7 +477,7 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private Map<String, String> getLimitAndOffsetParams(int limit, int offset, boolean includeItem) {
-    if (!includeItem) {
+    if (!includeItem || limit == 0) {
       return Map.of(
         "limit", "0");
     }

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -763,6 +763,48 @@ public class PatronResourceImplTest {
     logger.info("Test done");
   }
 
+  @Test
+  public final void testGetPatronAccountByIdWithAllRecordsWhenLimitNegative() {
+    logger.info("Testing for successful patron services account retrieval by id");
+
+    final Response response = given()
+      .log().all()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .pathParam("accountId", goodUserId)
+      .queryParam("limit", "-1")
+      .queryParam("includeLoans", "true")
+      .queryParam("includeHolds", "true")
+      .queryParam("includeCharges", "true")
+      .when()
+      .get(accountPath)
+      .then()
+      .log().all()
+      .contentType(ContentType.JSON)
+      .statusCode(200)
+      .extract().response();
+
+    final String body = response.getBody().asString();
+    final JsonObject json = new JsonObject(body);
+    final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder + "/response_testGetPatronAccountById.json"));
+
+    assertEquals(3, json.getInteger("totalLoans"));
+    assertEquals(3, json.getJsonArray("loans").size());
+
+    assertEquals(3, json.getInteger("totalHolds"));
+    assertEquals(3, json.getJsonArray("holds").size());
+
+    JsonObject money = json.getJsonObject("totalCharges");
+    assertEquals(255.0, money.getDouble("amount"));
+    assertEquals("USD", money.getString("isoCurrencyCode"));
+    assertEquals(5, json.getInteger("totalChargesCount"));
+    assertEquals(5, json.getJsonArray("charges").size());
+
+    // Test done
+    logger.info("Test done");
+  }
+
 
   @Test
   public final void testGetPatronAccountByIdNoLists() {
@@ -773,6 +815,10 @@ public class PatronResourceImplTest {
         .header(urlHeader)
         .header(contentTypeHeader)
         .pathParam("accountId", goodUserId)
+        .queryParam("limit", "0")
+        .queryParam("includeLoans", "true")
+        .queryParam("includeHolds", "true")
+        .queryParam("includeCharges", "true")
       .when()
         .get(accountPath)
       .then()
@@ -780,6 +826,42 @@ public class PatronResourceImplTest {
         .contentType(ContentType.JSON)
         .statusCode(200)
         .extract().response();
+
+    final String body = r.getBody().asString();
+    final JsonObject json = new JsonObject(body);
+
+    assertEquals(3, json.getInteger("totalLoans"));
+    assertEquals(0, json.getJsonArray("loans").size());
+
+    assertEquals(3, json.getInteger("totalHolds"));
+    assertEquals(0, json.getJsonArray("holds").size());
+
+    final JsonObject money = json.getJsonObject("totalCharges");
+    assertEquals(0.0, money.getDouble("amount"));
+    assertEquals("USD", money.getString("isoCurrencyCode"));
+    assertEquals(3, json.getInteger("totalChargesCount"));
+    assertEquals(0, json.getJsonArray("charges").size());
+
+    // Test done
+    logger.info("Test done");
+  }
+
+  @Test
+  public final void testGetPatronAccountByIdNoListsWhenLimitZero() {
+    logger.info("Testing for successful patron services account retrieval by id without item lists");
+
+    final Response r = given()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .pathParam("accountId", goodUserId)
+      .when()
+      .get(accountPath)
+      .then()
+      .log().all()
+      .contentType(ContentType.JSON)
+      .statusCode(200)
+      .extract().response();
 
     final String body = r.getBody().asString();
     final JsonObject json = new JsonObject(body);

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -48,7 +48,6 @@ import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
 public class PatronResourceImplTest {
-
   private final Logger logger = LogManager.getLogger();
 
   private String moduleName;
@@ -178,7 +177,7 @@ public class PatronResourceImplTest {
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile(mockDataFolder + "/loans_all_active.json"));
-        } else if (loansParametersMatch(req, 1)) {
+        } else if (loansParametersMatch(req, 0)) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
@@ -188,6 +187,11 @@ public class PatronResourceImplTest {
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile(mockDataFolder + "/loans_all_active_and_sorted.json"));
+        } else if (loansParametersMatch(req, 2) && offsetMatch(req, 1)) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile(mockDataFolder + "/loans_one_record.json"));
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
@@ -246,7 +250,7 @@ public class PatronResourceImplTest {
               .setStatusCode(200)
               .putHeader("content-type", "application/json")
               .end(readMockFile(mockDataFolder + "/holds_all_active.json"));
-          } else if (requestsParametersMatch(req, 1)) {
+          } else if (requestsParametersMatch(req, 0)) {
             req.response()
               .setStatusCode(200)
               .putHeader("content-type", "application/json")
@@ -256,6 +260,11 @@ public class PatronResourceImplTest {
               .setStatusCode(200)
               .putHeader("content-type", "application/json")
               .end(readMockFile(mockDataFolder + "/holds_all_active_and_sorted.json"));
+          } else if (requestsParametersMatch(req, 2) && offsetMatch(req, 1)) {
+            req.response()
+              .setStatusCode(200)
+              .putHeader("content-type", "application/json")
+              .end(readMockFile(mockDataFolder + "/holds_one_record.json"));
           } else {
             req.response().setStatusCode(500).end("Unexpected call: " + req.path());
           }
@@ -355,7 +364,7 @@ public class PatronResourceImplTest {
           .setStatusCode(200)
           .putHeader("content-type", "application/json")
           .end(readMockFile(mockDataFolder + "/accounts_all_inactive.json"));
-        } else if (accountParametersMatch(req)) {
+        } else if (accountParametersMatch(req, Integer.MAX_VALUE)) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
@@ -365,6 +374,16 @@ public class PatronResourceImplTest {
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile(mockDataFolder + "/accounts_all_active_and_sorted.json"));
+        } else if (accountParametersMatch(req, 0)) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile(mockDataFolder + "/accounts_total.json"));
+        } else if (accountParametersMatch(req, 2) && offsetMatch(req, 1)) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile(mockDataFolder + "/accounts_one_record.json"));
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
@@ -565,11 +584,11 @@ public class PatronResourceImplTest {
     server.listen(serverPort, host, context.succeeding(id -> mockOkapiStarted.flag()));
   }
 
-  private boolean accountParametersMatch(HttpServerRequest request) {
+  private boolean accountParametersMatch(HttpServerRequest request, int limit) {
     final var queryString = UrlDecoder.decode(request.query());
 
-    return queryString.contains("limit=" + Integer.MAX_VALUE)
-      && queryString.contains(String.format("query=(userId==%s and status.name==Open)", goodUserId));
+    return queryString.contains("limit=" + limit)
+      && queryString.contains("query=(userId==" + goodUserId + " and status.name==Open)");
   }
 
   private boolean accountParametersWithSortByMatch(HttpServerRequest request) {
@@ -621,6 +640,12 @@ public class PatronResourceImplTest {
       && queryString.contains("loan_type_id=" + loanTypeId1)
       && queryString.contains("patron_type_id=" + patronGroupId1)
       && queryString.contains("location_id=" + effectiveLocation1);
+  }
+
+  private boolean offsetMatch(HttpServerRequest request, int offset) {
+    final var queryString = UrlDecoder.decode(request.query());
+
+    return queryString.contains("offset=" + offset);
   }
 
   @AfterEach
@@ -694,6 +719,52 @@ public class PatronResourceImplTest {
   }
 
   @Test
+  public final void testGetPatronAccountByIdWithLimitAndOffset() {
+    logger.info("Testing for successful patron services account retrieval by id");
+
+    final Response response = given()
+      .log().all()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .pathParam("accountId", goodUserId)
+      .queryParam("limit", "2")
+      .queryParam("offset", "1")
+      .queryParam("includeLoans", "true")
+      .queryParam("includeHolds", "true")
+      .queryParam("includeCharges", "true")
+      .when()
+      .get(accountPath)
+      .then()
+      .log().all()
+      .contentType(ContentType.JSON)
+      .statusCode(200)
+      .extract().response();
+
+    final String body = response.getBody().asString();
+    final JsonObject json = new JsonObject(body);
+    final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder + "/response_testGetPatronAccountByIdByLimitAndOffset.json"));
+
+    assertEquals(1, json.getInteger("totalLoans"));
+    assertEquals(1, json.getJsonArray("loans").size());
+
+    assertEquals(1, json.getInteger("totalHolds"));
+    assertEquals(1, json.getJsonArray("holds").size());
+
+    JsonObject money = json.getJsonObject("totalCharges");
+    assertEquals(50.0, money.getDouble("amount"));
+    assertEquals("USD", money.getString("isoCurrencyCode"));
+    assertEquals(1, json.getInteger("totalChargesCount"));
+    assertEquals(1, json.getJsonArray("charges").size());
+
+    assertEquals(expectedJson, json);
+
+    // Test done
+    logger.info("Test done");
+  }
+
+
+  @Test
   public final void testGetPatronAccountByIdNoLists() {
     logger.info("Testing for successful patron services account retrieval by id without item lists");
 
@@ -720,9 +791,9 @@ public class PatronResourceImplTest {
     assertEquals(0, json.getJsonArray("holds").size());
 
     final JsonObject money = json.getJsonObject("totalCharges");
-    assertEquals(255.0, money.getDouble("amount"));
+    assertEquals(0.0, money.getDouble("amount"));
     assertEquals("USD", money.getString("isoCurrencyCode"));
-    assertEquals(5, json.getInteger("totalChargesCount"));
+    assertEquals(3, json.getInteger("totalChargesCount"));
     assertEquals(0, json.getJsonArray("charges").size());
 
     // Test done

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -723,23 +723,23 @@ public class PatronResourceImplTest {
     logger.info("Testing for successful patron services account retrieval by id");
 
     final Response response = given()
-      .log().all()
-      .header(tenantHeader)
-      .header(urlHeader)
-      .header(contentTypeHeader)
-      .pathParam("accountId", goodUserId)
-      .queryParam("limit", "2")
-      .queryParam("offset", "1")
-      .queryParam("includeLoans", "true")
-      .queryParam("includeHolds", "true")
-      .queryParam("includeCharges", "true")
+        .log().all()
+        .header(tenantHeader)
+        .header(urlHeader)
+        .header(contentTypeHeader)
+        .pathParam("accountId", goodUserId)
+        .queryParam("limit", "2")
+        .queryParam("offset", "1")
+        .queryParam("includeLoans", "true")
+        .queryParam("includeHolds", "true")
+        .queryParam("includeCharges", "true")
       .when()
-      .get(accountPath)
+        .get(accountPath)
       .then()
-      .log().all()
-      .contentType(ContentType.JSON)
-      .statusCode(200)
-      .extract().response();
+        .log().all()
+        .contentType(ContentType.JSON)
+        .statusCode(200)
+        .extract().response();
 
     final String body = response.getBody().asString();
     final JsonObject json = new JsonObject(body);
@@ -764,30 +764,29 @@ public class PatronResourceImplTest {
   }
 
   @Test
-  public final void testGetPatronAccountByIdWithAllRecordsWhenLimitNegative() {
+  public final void testGetPatronAccountByIdReturnsAllRecordsWhenLimitNegative() {
     logger.info("Testing for successful patron services account retrieval by id");
 
     final Response response = given()
-      .log().all()
-      .header(tenantHeader)
-      .header(urlHeader)
-      .header(contentTypeHeader)
-      .pathParam("accountId", goodUserId)
-      .queryParam("limit", "-1")
-      .queryParam("includeLoans", "true")
-      .queryParam("includeHolds", "true")
-      .queryParam("includeCharges", "true")
+        .log().all()
+        .header(tenantHeader)
+        .header(urlHeader)
+        .header(contentTypeHeader)
+        .pathParam("accountId", goodUserId)
+        .queryParam("limit", "-1")
+        .queryParam("includeLoans", "true")
+        .queryParam("includeHolds", "true")
+        .queryParam("includeCharges", "true")
       .when()
-      .get(accountPath)
+        .get(accountPath)
       .then()
-      .log().all()
-      .contentType(ContentType.JSON)
-      .statusCode(200)
+        .log().all()
+        .contentType(ContentType.JSON)
+        .statusCode(200)
       .extract().response();
 
     final String body = response.getBody().asString();
     final JsonObject json = new JsonObject(body);
-    final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder + "/response_testGetPatronAccountById.json"));
 
     assertEquals(3, json.getInteger("totalLoans"));
     assertEquals(3, json.getJsonArray("loans").size());
@@ -851,17 +850,17 @@ public class PatronResourceImplTest {
     logger.info("Testing for successful patron services account retrieval by id without item lists");
 
     final Response r = given()
-      .header(tenantHeader)
-      .header(urlHeader)
-      .header(contentTypeHeader)
-      .pathParam("accountId", goodUserId)
+        .header(tenantHeader)
+        .header(urlHeader)
+        .header(contentTypeHeader)
+        .pathParam("accountId", goodUserId)
       .when()
-      .get(accountPath)
+        .get(accountPath)
       .then()
-      .log().all()
-      .contentType(ContentType.JSON)
-      .statusCode(200)
-      .extract().response();
+        .log().all()
+        .contentType(ContentType.JSON)
+        .statusCode(200)
+        .extract().response();
 
     final String body = r.getBody().asString();
     final JsonObject json = new JsonObject(body);

--- a/src/test/resources/PatronServicesResourceImpl/accounts_one_record.json
+++ b/src/test/resources/PatronServicesResourceImpl/accounts_one_record.json
@@ -1,0 +1,33 @@
+{
+  "accounts": [{
+    "amount": 100.0,
+    "remaining": 50.0,
+    "accountTransaction": 1,
+    "status": {
+      "name": "Open"
+    },
+    "paymentStatus": {
+      "name": "Paid Partially"
+    },
+    "metadata":{
+      "createdDate": "2018-01-31T00:00:01Z",
+      "updatedDate": "2018-01-31T00:00:01Z"
+    },
+    "feeFineType": "damage - rebinding",
+    "feeFineOwner": "Main library Ciculation Desk",
+    "title": "Some Book About Something",
+    "callNumber": "Book 1 call number",
+    "barcode": "1234567890",
+    "materialType": "book",
+    "itemStatus": {"name": "Checked out"},
+    "location": "Main library",
+    "loanId": "9a171a89-baca-4f1a-b2c4-d7253854864e",
+    "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+    "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+    "itemId": "7d9dfe70-0158-489d-a7ed-2789eac277b3",
+    "feeFineId": "881c628b-e1c4-4711-b9d7-090af40f6a8f",
+    "ownerId": "cfebe06e-d4f8-4d4e-8f5c-4d70595d74f8",
+    "id": "749bf599-3a31-494e-9fa4-268a5b67fdde"
+  }],
+  "totalRecords": 1
+}

--- a/src/test/resources/PatronServicesResourceImpl/accounts_total.json
+++ b/src/test/resources/PatronServicesResourceImpl/accounts_total.json
@@ -1,0 +1,4 @@
+{
+  "accounts": [],
+  "totalRecords": 3
+}

--- a/src/test/resources/PatronServicesResourceImpl/holds_one_record.json
+++ b/src/test/resources/PatronServicesResourceImpl/holds_one_record.json
@@ -1,0 +1,24 @@
+{
+  "requests": [
+    {
+      "id": "24a5de73-859b-491f-825d-a96ea47297fb",
+      "requesterId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+      "itemId": "dbdcb2b5-b302-4254-a55d-3c429794a4bb",
+      "requestType": "Hold",
+      "requestDate": "2018-05-01T05:01:15Z",
+      "fulfilmentPreference": "Hold Shelf",
+      "status": "Open - Awaiting pickup",
+      "position": 3,
+      "item" :{
+        "title": "Hold On",
+        "instanceId": "0b559683-9059-4b6d-bb6a-c55aa3518df3",
+        "contributors": [
+          {"name": "Jon Anderson"},
+          {"name": "Trevor Rabin"},
+          {"name": "Chris Squire"}
+        ]
+      }
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/PatronServicesResourceImpl/loans_one_record.json
+++ b/src/test/resources/PatronServicesResourceImpl/loans_one_record.json
@@ -1,0 +1,20 @@
+{
+  "loans": [
+    {
+      "id": "76d957eb-df99-41b8-a495-d03541d079fb",
+      "userId": "1ec54964-70f0-44cc-bd19-2a892ea0d336",
+      "itemId": "7d4bfd9c-dc46-46a1-89bd-160c61fe46d8",
+      "loanDate": "2018-03-05T22:01:00.000Z",
+      "dueDate": "2018-04-01T09:50:00.000Z",
+      "action": "checkedout",
+      "item": {
+        "instanceId": "b3f5ef6d-2309-4935-858d-870cd7801632",
+        "title": "This Book Is Overdue!",
+        "contributors" : [
+          {"name": "Tempus Fugit"}
+        ]
+      }
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountByIdByLimitAndOffset.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testGetPatronAccountByIdByLimitAndOffset.json
@@ -1,0 +1,54 @@
+{
+    "totalCharges": {
+        "amount": 50.0,
+        "isoCurrencyCode": "USD"
+    },
+    "totalChargesCount": 1,
+    "totalLoans": 1,
+    "totalHolds": 1,
+    "charges": [
+      {
+        "item" : {
+          "instanceId" : "6e024cd5-c19a-4fe0-a2cd-64ce5814c694",
+          "itemId" : "7d9dfe70-0158-489d-a7ed-2789eac277b3",
+          "title" : "Some Book About Something",
+          "author" : "Some Guy; Another Guy"
+        },
+        "chargeAmount" : {
+          "amount" : 50.0,
+          "isoCurrencyCode" : "USD"
+        },
+        "accrualDate" : "2018-01-31T00:00:01.000+00:00",
+        "state" : "Paid Partially",
+        "reason" : "damage - rebinding"
+      }
+    ],
+    "holds": [
+        {
+            "requestId": "24a5de73-859b-491f-825d-a96ea47297fb",
+            "item": {
+                "instanceId": "0b559683-9059-4b6d-bb6a-c55aa3518df3",
+                "itemId": "dbdcb2b5-b302-4254-a55d-3c429794a4bb",
+                "title": "Hold On",
+                "author": "Jon Anderson; Trevor Rabin; Chris Squire"
+            },
+            "requestDate": "2018-05-01T05:01:15.000+00:00",
+            "status": "Open - Awaiting pickup",
+            "queuePosition":3
+        }
+    ],
+    "loans": [
+        {
+            "id": "76d957eb-df99-41b8-a495-d03541d079fb",
+            "item": {
+                "instanceId": "b3f5ef6d-2309-4935-858d-870cd7801632",
+                "itemId": "7d4bfd9c-dc46-46a1-89bd-160c61fe46d8",
+                "title": "This Book Is Overdue!",
+                "author": "Tempus Fugit"
+            },
+            "loanDate": "2018-03-05T22:01:00.000+00:00",
+            "dueDate": "2018-04-01T09:50:00.000+00:00",
+            "overdue": true
+        }
+    ]
+}


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODPATRON-j80

Introduce new query paramters "limit" and "offset" for GET /patron/account/{id} endpoint to support paging the lists of {holds, loans, charges} in  account info responses. 
## Approach
1) Update GET /patron/account/{id} endpoint in patron.raml with "limit" and "offset" query parameter
2) Update PatronServicesResourceImpl to append limit and offset when retrieve loans (GET /circulation/loans), charges (GET /accounts) and holds (GET /circulation/requests) by next logic:

    1. If includeItem is false, set limit=0, regardless of whether limit was provided in the incoming request or not.
    2. else
        a) If limit was specified on the incoming request, use this value and include offset if it was specified.
        b) else, use Integer.MAX_VALUE.


3) Update unit tests 
