### PR TITLE
Fix limit for charges when includeCharges equals false

### DIFF
--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -76,8 +76,7 @@ public class PatronServicesResourceImpl implements Patron {
               httpClient)
                 .thenApply(body -> addHolds(account, body, includeHolds));
 
-            final CompletableFuture<Account> cf3 = getAccounts(id, sortBy, limit, offset, includeCharges,
-              okapiHeaders, httpClient)
+            final CompletableFuture<Account> cf3 = getAccounts(id, sortBy, limit, offset, okapiHeaders, httpClient)
                 .thenApply(body -> addCharges(account, body, includeCharges))
                 .thenCompose(charges -> {
                   if (includeCharges) {
@@ -114,11 +113,11 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private CompletableFuture<JsonObject> getAccounts(String id,
-    String sortBy, int limit, int offset, boolean includeCharges,
+    String sortBy, int limit, int offset,
     Map<String, String> okapiHeaders, VertxOkapiHttpClient httpClient) {
 
     Map<String, String> queryParameters = Maps.newLinkedHashMap();
-    queryParameters.putAll(getLimitAndOffsetParams(limit, offset, includeCharges));
+    queryParameters.putAll(getLimitAndOffsetParams(limit, offset, true));
     queryParameters.put("query", buildQueryWithUserId(id, sortBy));
 
     return httpClient.get("/accounts", queryParameters, okapiHeaders)

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -872,9 +872,9 @@ public class PatronResourceImplTest {
     assertEquals(0, json.getJsonArray("holds").size());
 
     final JsonObject money = json.getJsonObject("totalCharges");
-    assertEquals(0.0, money.getDouble("amount"));
+    assertEquals(255.0, money.getDouble("amount"));
     assertEquals("USD", money.getString("isoCurrencyCode"));
-    assertEquals(3, json.getInteger("totalChargesCount"));
+    assertEquals(5, json.getInteger("totalChargesCount"));
     assertEquals(0, json.getJsonArray("charges").size());
 
     // Test done


### PR DESCRIPTION
## Purpose
In case if the /patron/account is called and includeCharges param equal false we still should get all charges to calculate charges "amount" to add this information to "chargesTotal.amount". 

## Approach
Update getAccount() in PatronServicesResourceImpl class to always pass value "true" instead of includeCharges variable to getLimitAndOffset method. In this case, limit value is set from limit param if it presents, otherwise, Integer.MAX_VALUE value is set