### PR TITLE
MODPATRON-94: Upgrade to RMB 33.0.4 and Log4J to 2.16.0 (Kiwi R3 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 5.0.3 IN-PROGRESS
+
+* Upgrade to RMB 33.0.4 and Log4J to 2.16.0. (CVE-2021-44228) (MODPATRON-94)
+
 ## 5.0.2 2021-11-11
 
 * Adding permission to base endpoint to resolve a bug (MODPATRON-77) 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aspectj.version>1.9.6</aspectj.version>
-    <raml-module-builder.version>33.0.2</raml-module-builder.version>
+    <raml-module-builder.version>33.0.4</raml-module-builder.version>
     <vertx.version>4.1.0</vertx.version>
   </properties>
 
@@ -517,7 +517,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODPATRON-94](https://issues.folio.org/browse/MODPATRON-94).