### PR TITLE
MODPATRON-96: Upgrade to RMB 32.2.4 and Log4J to 2.16.0 (Juniper R2 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 4.5.3 IN-PROGRESS
+
+* Upgrade to RMB 32.2.4 and Log4J to 2.16.0. (CVE-2021-44228) (MODPATRON-96)
+
 ## 4.5.2 2021-09-15
 
 * Fixes logging output (MODPATRON-70)

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aspectj.version>1.9.6</aspectj.version>
-    <raml-module-builder.version>32.1.0</raml-module-builder.version>
+    <raml-module-builder.version>32.2.4</raml-module-builder.version>
   </properties>
 
   <repositories>
@@ -481,7 +481,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODPATRON-96](https://issues.folio.org/browse/MODPATRON-96).