### PR TITLE
MODPATRON-104 Do not pass request level to mod-circulation when creating instance request

### DIFF
--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -14,7 +14,6 @@ import static org.folio.rest.impl.Constants.JSON_FIELD_PICKUP_SERVICE_POINT_ID;
 import static org.folio.rest.impl.Constants.JSON_FIELD_REQUESTER_ID;
 import static org.folio.rest.impl.Constants.JSON_FIELD_REQUEST_DATE;
 import static org.folio.rest.impl.Constants.JSON_FIELD_REQUEST_EXPIRATION_DATE;
-import static org.folio.rest.impl.Constants.JSON_FIELD_REQUEST_LEVEL;
 import static org.folio.rest.impl.Constants.JSON_FIELD_TITLE;
 import static org.folio.rest.impl.Constants.JSON_FIELD_TOTAL_RECORDS;
 import static org.folio.rest.impl.Constants.JSON_FIELD_USER_ID;
@@ -38,9 +37,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.integration.http.HttpClientFactory;
 import org.folio.integration.http.ResponseInterpreter;
 import org.folio.integration.http.VertxOkapiHttpClient;
@@ -309,7 +305,6 @@ public class PatronServicesResourceImpl implements Patron {
     final JsonObject holdJSON = new JsonObject()
         .put(JSON_FIELD_INSTANCE_ID, instanceId)
         .put(JSON_FIELD_REQUESTER_ID, id)
-        .put(JSON_FIELD_REQUEST_LEVEL, "Item")
         .put(JSON_FIELD_REQUEST_DATE, new DateTime(entity.getRequestDate(), DateTimeZone.UTC).toString())
         .put(JSON_FIELD_PICKUP_SERVICE_POINT_ID, entity.getPickupLocationId())
         .put(JSON_FIELD_PATRON_COMMENTS, entity.getPatronComments());

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -301,7 +301,7 @@ public class PatronResourceImplTest {
                 .putHeader("content-type", "text/plain")
                 .end(badDataValue);
             }
-          } else if (tlrEnabled && req.getHeader("X-Okapi-TLR-no-item-id") != null) {
+          } else if (tlrEnabled && req.getHeader("X-Okapi-TLR-No-Item-id") != null) {
             req.response()
               .setStatusCode(201)
               .putHeader("content-type", "application/json")
@@ -1293,7 +1293,7 @@ public class PatronResourceImplTest {
 
     if (noItemId) {
       headers = new Headers(tenantHeader, urlHeader, contentTypeHeader,
-        new Header("X-Okapi-TLR-no-item-id", "application/json"));
+        new Header("X-Okapi-TLR-No-Item-id", "application/json"));
     } else {
       headers =  new Headers(tenantHeader, urlHeader, contentTypeHeader);
     }

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -63,7 +63,6 @@ public class PatronResourceImplTest {
   private final Header tenantHeader = new Header("X-Okapi-Tenant", "patronresourceimpltest");
   private final Header urlHeader = new Header("X-Okapi-Url", "http://localhost:" + serverPort);
   private final Header contentTypeHeader = new Header("Content-Type", "application/json");
-  private final Header noItemId = new Header("X-Okapi-TLR-no-item-id", "application/json");
 
   private final String mockDataFolder = "PatronServicesResourceImpl";
   private final String accountPath = "/patron/account/{accountId}";
@@ -1284,13 +1283,23 @@ public class PatronResourceImplTest {
   @ParameterizedTest
   @MethodSource("tlrFeatureStates")
   public final void testPostPatronAccountByIdInstanceByInstanceIdHold(String responseFile,
-    boolean tlrState) {
+    boolean tlrState, boolean noItemId) {
 
     logger.info("Testing creating a hold on an instance for the specified user");
 
     tlrEnabled = tlrState;
+
+    Headers headers;
+
+    if (noItemId) {
+      headers = new Headers(tenantHeader, urlHeader, contentTypeHeader,
+        new Header("X-Okapi-TLR-no-item-id", "application/json"));
+    } else {
+      headers =  new Headers(tenantHeader, urlHeader, contentTypeHeader);
+    }
+
     final var hold = given()
-        .headers(new Headers(tenantHeader, urlHeader, contentTypeHeader, noItemId))
+        .headers(headers)
         .and().pathParams("accountId", goodUserId, "instanceId", goodInstanceId)
         .and().body(readMockFile(mockDataFolder
             + "/request_testPostPatronAccountByIdInstanceByInstanceIdHold.json"))
@@ -1474,8 +1483,8 @@ public class PatronResourceImplTest {
 
   static Stream<Arguments> tlrFeatureStates() {
     return Stream.of(
-      Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHoldNoItemId.json", true),
-      Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHold.json", false)
+      Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHoldNoItemId.json", true, true),
+      Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHold.json", false, false)
     );
   }
 

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -1201,7 +1201,7 @@ public class PatronResourceImplTest {
 
     final var expectedHold = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"));
 
-    verifyHold(expectedHold, new JsonObject(holdCancelResponse), null);
+    verifyHold(expectedHold, new JsonObject(holdCancelResponse));
 
     // Test done
     logger.info("Test done");
@@ -1237,7 +1237,7 @@ public class PatronResourceImplTest {
 
     final var expectedHold = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"));
 
-    verifyHold(expectedHold, new JsonObject(holdCancelResponse), null);
+    verifyHold(expectedHold, new JsonObject(holdCancelResponse));
 
     // Test done
     logger.info("Test done");
@@ -1284,7 +1284,7 @@ public class PatronResourceImplTest {
   @ParameterizedTest
   @MethodSource("tlrFeatureStates")
   public final void testPostPatronAccountByIdInstanceByInstanceIdHold(String responseFile,
-    boolean tlrState, String tlrNoItemId) {
+    boolean tlrState) {
 
     logger.info("Testing creating a hold on an instance for the specified user");
 
@@ -1305,7 +1305,7 @@ public class PatronResourceImplTest {
 
     final var expectedHold = new JsonObject(readMockFile(mockDataFolder + responseFile));
 
-    verifyHold(expectedHold, new JsonObject(hold), tlrNoItemId);
+    verifyHold(expectedHold, new JsonObject(hold));
 
     // Test done
     logger.info("Test done");
@@ -1474,8 +1474,8 @@ public class PatronResourceImplTest {
 
   static Stream<Arguments> tlrFeatureStates() {
     return Stream.of(
-      Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHoldNoItemId.json", true, "tlrhasnoitem"),
-      Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHold.json", false, null)
+      Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHoldNoItemId.json", true),
+      Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHold.json", false)
     );
   }
 
@@ -1591,7 +1591,7 @@ public class PatronResourceImplTest {
       boolean found = false;
       for (int j = 0; j < 3; j++) {
         final JsonObject expectedJO = expectedAccountJson.getJsonArray("holds").getJsonObject(j);
-        if (verifyHold(expectedJO, jo, null)) {
+        if (verifyHold(expectedJO, jo)) {
           found = true;
           break;
         }
@@ -1626,12 +1626,12 @@ public class PatronResourceImplTest {
   }
 
   private void verifyRequests(JsonObject expectedHold, JsonObject actualHold) {
-    if (!verifyHold(expectedHold, actualHold, null)) {
+    if (!verifyHold(expectedHold, actualHold)) {
       fail("verification of request objects failed");
     }
   }
 
-  private boolean verifyHold(JsonObject expectedHold, JsonObject actualHold, String tlrNoItemId) {
+  private boolean verifyHold(JsonObject expectedHold, JsonObject actualHold) {
     if (expectedHold.getString("requestId").equals(actualHold.getString("requestId"))) {
       assertEquals(expectedHold.getString("pickupLocationId"), actualHold.getString("pickupLocationId"));
       assertEquals(expectedHold.getString("status"), actualHold.getString("status"));
@@ -1641,7 +1641,7 @@ public class PatronResourceImplTest {
           actualHold.getInteger("requestPosition"));
       assertEquals(expectedHold.getString("patronComments"),
           actualHold.getString("patronComments"));
-      return verifyItem(expectedHold.getJsonObject("item"), actualHold.getJsonObject("item"), tlrNoItemId);
+      return verifyItem(expectedHold.getJsonObject("item"), actualHold.getJsonObject("item"));
     }
     return false;
   }
@@ -1659,17 +1659,13 @@ public class PatronResourceImplTest {
   }
 
   private boolean verifyItem(JsonObject expectedItem, JsonObject actualItem) {
-    return verifyItem(expectedItem, actualItem, null);
-  }
+    if (Objects.equals(expectedItem.getString("itemId"), actualItem.getString("itemId"))) {
+      assertEquals(expectedItem.getString("instanceId"), actualItem.getString("instanceId"));
+      assertEquals(expectedItem.getString("title"), actualItem.getString("title"));
+      assertEquals(expectedItem.getString("author"), actualItem.getString("author"));
 
-  private boolean verifyItem(JsonObject expectedItem, JsonObject actualItem, String noItemId) {
-    assertEquals(expectedItem.getString("instanceId"), actualItem.getString("instanceId"));
-    assertEquals(expectedItem.getString("title"), actualItem.getString("title"));
-    assertEquals(expectedItem.getString("author"), actualItem.getString("author"));
-    if (tlrEnabled && noItemId != null) {
-      assertEquals(expectedItem.getString("itemId"),actualItem.getString("itemId"));
+      return true;
     }
-
-    return true;
+    return false;
   }
 }

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -302,11 +302,11 @@ public class PatronResourceImplTest {
                 .putHeader("content-type", "text/plain")
                 .end(badDataValue);
             }
-          } else if (tlrEnabled && req.getHeader("X-No-Item-Id") != null) {
+          } else if (tlrEnabled && req.getHeader("X-Okapi-TLR-no-item-id") != null) {
             req.response()
               .setStatusCode(201)
               .putHeader("content-type", "application/json")
-              .end(readMockFile(mockDataFolder + "/instance_hold_tlr_create.json"));
+              .end(readMockFile(mockDataFolder + "/instance_holds_tlr_create.json"));
           } else {
             req.response()
               .setStatusCode(201)
@@ -1290,7 +1290,7 @@ public class PatronResourceImplTest {
 
     tlrEnabled = tlrState;
     final var hold = given()
-        .headers(new Headers(tenantHeader, urlHeader, contentTypeHeader, new Header("X-No-Item-Id", tlrNoItemId)))
+        .headers(new Headers(tenantHeader, urlHeader, contentTypeHeader, noItemId))
         .and().pathParams("accountId", goodUserId, "instanceId", goodInstanceId)
         .and().body(readMockFile(mockDataFolder
             + "/request_testPostPatronAccountByIdInstanceByInstanceIdHold.json"))

--- a/src/test/resources/PatronServicesResourceImpl/instance_holds_tlr_create.json
+++ b/src/test/resources/PatronServicesResourceImpl/instance_holds_tlr_create.json
@@ -1,0 +1,63 @@
+{
+  "id": "d0f032db-9579-443e-a2ac-6add937f4aa2",
+  "requestLevel": "Title",
+  "requestType": "Hold",
+  "requestDate": "2021-09-06T15:37:55.000+00:00",
+  "requestExpirationDate": "3000-01-30T08:16:30Z",
+  "requesterId": "bec20636-fb68-41fd-84ea-2cf910673599",
+  "status": "Open - Not yet filled",
+  "instanceId": "23611f0b-35cc-4f40-af09-75907d7cc421",
+  "holdingsRecordId": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
+  "patronComments": "I need this book. Instance level comment.",
+  "instance": {
+    "title": "A semantic web primer",
+    "identifiers": [
+      {
+        "value": "0262012103",
+        "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+      },
+      {
+        "value": "9780262012102",
+        "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+      },
+      {
+        "value": "2003065165",
+        "identifierTypeId": "c858e4f2-2b6b-4385-842b-60732ee14abb"
+      }
+    ],
+    "contributorNames": [
+      {
+        "name": "Antoniou, Grigoris"
+      },
+      {
+        "name": "Van Harmelen, Frank"
+      }
+    ]
+  },
+  "requester": {
+    "lastName": "morty",
+    "firstName": "panic",
+    "barcode": "456",
+    "patronGroupId": "3684a786-6671-4268-8ed0-9db82ebca60b"
+  },
+  "fulfilmentPreference": "Hold Shelf",
+  "pickupServicePointId": "c4c90014-c8c9-4ade-8f24-b5e313319f4b",
+  "metadata": {
+    "createdDate": "2021-09-06T15:37:56.188+00:00",
+    "createdByUserId": "226dfeeb-0264-57fc-afcd-d5df2d705dd5",
+    "updatedDate": "2021-09-06T15:37:56.188+00:00",
+    "updatedByUserId": "226dfeeb-0264-57fc-afcd-d5df2d705dd5"
+  },
+  "position": 1,
+  "loan": {
+    "dueDate": "2021-09-06T16:36:56.029Z"
+  },
+  "pickupServicePoint": {
+    "name": "Circ Desk 2",
+    "code": "cd2",
+    "discoveryDisplayName": "Circulation Desk -- Back Entrance",
+    "description": null,
+    "shelvingLagTime": null,
+    "pickupLocation": true
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdInstanceByInstanceIdHoldNoItemId.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdInstanceByInstanceIdHoldNoItemId.json
@@ -1,0 +1,14 @@
+{
+  "requestId": "d0f032db-9579-443e-a2ac-6add937f4aa2",
+  "requestDate": "2021-09-06T15:37:55.000+00:00",
+  "item": {
+    "instanceId": "23611f0b-35cc-4f40-af09-75907d7cc421",
+    "title": "A semantic web primer",
+    "author": "Antoniou, Grigoris; Van Harmelen, Frank"
+  },
+  "queuePosition": 1,
+  "expirationDate": "3000-01-30T08:16:30Z",
+  "status": "Open - Not yet filled",
+  "pickupLocationId": "c4c90014-c8c9-4ade-8f24-b5e313319f4b",
+  "patronComments": "I need this book. Instance level comment."
+}


### PR DESCRIPTION
Resolves: https://issues.folio.org/browse/MODPATRON-104.
When attempting to create a request via edge/mod-patron using the /patron/account/<patronId>/instance/<instanceId>/hold endpoint with TLR enabled, a true title-level request should be created (requestLevel="Title"). Instead, every request made via this endpoint results in an item-level request (TLR-lite).
The main fix is expected to be in mod-circulation, but a test should be added in mod-patron for how it behaves if it recieves TLR without item.