### PR TITLE
MODPATRON-110 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,11 @@ buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
-  runLintRamlCop = 'yes'
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 buildMvn {
   publishModDescriptor = 'yes'
-  publishAPI = 'yes'
   mvnDeploy = 'yes'
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-patron
 
-Copyright (C) 2018-2019 The Open Library Foundation
+Copyright (C) 2018-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/account.json
+++ b/ramls/account.json
@@ -18,17 +18,17 @@
     "totalChargesCount": {
       "type": "integer",
       "description": "The total number of fines and charges for the patron",
-      "example": "10"
+      "example": 10
     },
     "totalLoans": {
       "type": "integer",
       "description": "The total number of items loaned to the patron",
-      "example": "10"
+      "example": 10
     },
     "totalHolds": {
       "type": "integer",
       "description": "The total number of requested items for the patron",
-      "example": "10"
+      "example": 10
     },
     "charges": {
       "type": "array",

--- a/ramls/money.json
+++ b/ramls/money.json
@@ -8,7 +8,7 @@
     "amount": {
       "type": "number",
       "description": "The amount of the fine or charge",
-      "example": "3.14"
+      "example": 3.14
     },
     "isoCurrencyCode": {
       "type": "string",

--- a/ramls/patron.raml
+++ b/ramls/patron.raml
@@ -88,7 +88,7 @@ traits:
             description: Returns the user account info
             body:
               application/json:
-                schema: account
+                type: account
                 example: !include examples/account.json
           400:
             description: Bad request
@@ -133,7 +133,7 @@ traits:
                   description: Returns the renewed loan data
                   body:
                     application/json:
-                      schema: loan
+                      type: loan
                       example: !include examples/loan.json
                 400:
                   description: Bad request
@@ -175,7 +175,7 @@ traits:
               is: [validate]
               body:
                 application/json:
-                  schema: hold
+                  type: hold
                   example: !include examples/hold.json
               responses:
                 201:
@@ -183,7 +183,7 @@ traits:
                     Returns data for a new hold request on the specified item
                   body:
                     application/json:
-                      schema: hold
+                      type: hold
                       example: !include examples/hold.json
                 400:
                   description: Bad request
@@ -240,7 +240,7 @@ traits:
               is: [validate]
               body:
                 application/json:
-                  schema: hold
+                  type: hold
                   example: !include examples/hold.json
               responses:
                 201:
@@ -248,7 +248,7 @@ traits:
                     Returns data for a new hold request on the selected item
                   body:
                     application/json:
-                      schema: hold
+                      type: hold
                       example: !include examples/hold.json
                 400:
                   description: Bad request
@@ -295,7 +295,7 @@ traits:
               description: cancels the request
               body:
                 application/json:
-                  schema: hold
+                  type: hold
                   example: !include examples/hold.json
               responses:
                 200:
@@ -303,7 +303,7 @@ traits:
                     Returns an updated hold request after cancelling
                   body:
                     application/json:
-                      schema: hold
+                      type: hold
                       example: !include examples/hold.json
                 400:
                   description: Bad request
@@ -335,7 +335,7 @@ traits:
                   description: Validation error
                   body:
                     application/json:
-                      schema : errors
+                      type: errors
                 500:
                   description: |
                     Internal server error, e.g. due to misconfiguration


### PR DESCRIPTION
[MODPATRON-110](https://issues.folio.org/browse/MODPATRON-110)
[FOLIO-3231](https://issues.folio.org/browse/FOLIO-3231)

The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/
