### PR TITLE
MODPATRON-119: Improve error logging and response in mod-patron

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 5.3.0 IN-PROGRESS
 
+* Adding timeout and error handlers for requests to external modules (MODPATRON-119)
 * Upgrade to RMB 34.0.0 (MODPATRON-114)
 * Missing statuses added (MODPATRON-22)
 * Title-level requests properly created (MODPATRON-104)

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -42,11 +42,6 @@ public class VertxOkapiHttpClient {
     queryParameters.forEach(request::addQueryParam);
 
     return request.send()
-      .onFailure(err -> {
-        String errorMsg = "Error when trying to retrive data from " +
-          url.getPath() + " " + err.getMessage();
-        logger.error(errorMsg);
-      })
       .toCompletionStage()
       .toCompletableFuture()
       .thenApply(this::toResponse);
@@ -81,11 +76,6 @@ public class VertxOkapiHttpClient {
     HttpRequest<Buffer> request, JsonObject body, String path) {
 
     return request.sendJson(body)
-      .onFailure(err -> {
-        String errorMsg = "Error when trying to retrive data from " +
-          path + " " + err.getMessage();
-        logger.error(errorMsg);
-      })
       .toCompletionStage()
       .toCompletableFuture()
       .thenApply(this::toResponse);

--- a/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
+++ b/src/main/java/org/folio/integration/http/VertxOkapiHttpClient.java
@@ -13,14 +13,9 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 public class VertxOkapiHttpClient {
   private final WebClient client;
-  private static final Logger logger = LogManager.getLogger("okapi");
   
-
   public VertxOkapiHttpClient(WebClient client) {
     this.client = client;
   }
@@ -57,7 +52,7 @@ public class VertxOkapiHttpClient {
       .putHeaders(buildHeaders(okapiHeaders))
       .timeout(5000);
 
-    return makeRequestWithBody(request, body, url.getPath());
+    return makeRequestWithBody(request, body);
   }
 
   public CompletableFuture<Response> put(String path, JsonObject body,
@@ -69,11 +64,11 @@ public class VertxOkapiHttpClient {
       .put(url.getPort(), url.getHost(), url.getPath())
       .putHeaders(buildHeaders(okapiHeaders));
 
-    return makeRequestWithBody(request, body, url.getPath());
+    return makeRequestWithBody(request, body);
   }
 
   private CompletableFuture<Response> makeRequestWithBody(
-    HttpRequest<Buffer> request, JsonObject body, String path) {
+    HttpRequest<Buffer> request, JsonObject body) {
 
     return request.sendJson(body)
       .toCompletionStage()

--- a/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
+++ b/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
@@ -15,8 +15,8 @@ import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.HttpStatus.HTTP_OK;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
@@ -75,7 +75,7 @@ class VertxOkapiHttpClientTest {
     });
 
     String err = "The timeout period of 5000ms has been exceeded";
-    assertThat(exception.getMessage().indexOf(err), not(-1));
+    assertThat(exception.getMessage(), containsString(err));
 
   }
 

--- a/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
+++ b/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
@@ -71,7 +71,7 @@ class VertxOkapiHttpClientTest {
       "/record", Headers.toMap(fakeWebServer.baseUrl()));
 
     Exception exception = assertThrows(ExecutionException.class, ()->{
-      final var response = getCompleted.get(6, SECONDS);
+      getCompleted.get(6, SECONDS);
     });
 
     String err = "The timeout period of 5000ms has been exceeded";

--- a/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
+++ b/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,17 +31,12 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
-
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 import lombok.SneakyThrows;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 class VertxOkapiHttpClientTest {
-  private static final Logger logger = LogManager.getLogger("okapi");
   private final WireMockServer fakeWebServer = new WireMockServer(options().dynamicPort());
   private Vertx vertx;
 
@@ -73,13 +69,13 @@ class VertxOkapiHttpClientTest {
 
     final var getCompleted = client.get(
       "/record", Headers.toMap(fakeWebServer.baseUrl()));
-    try {
+
+    Exception exception = assertThrows(ExecutionException.class, ()->{
       final var response = getCompleted.get(6, SECONDS);
-      assertThat("Timeout exception should have been thrown.", response, is(-1));
-    } catch(Exception e) {
-      String err = "The timeout period of 5000ms has been exceeded";
-      assertThat(e.getMessage().indexOf(err), not(-1));
-    }
+    });
+
+    String err = "The timeout period of 5000ms has been exceeded";
+    assertThat(exception.getMessage().indexOf(err), not(-1));
 
   }
 

--- a/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
+++ b/src/test/java/org/folio/integration/http/VertxOkapiHttpClientTest.java
@@ -70,7 +70,7 @@ class VertxOkapiHttpClientTest {
     final var getCompleted = client.get(
       "/record", Headers.toMap(fakeWebServer.baseUrl()));
 
-    Exception exception = assertThrows(ExecutionException.class, ()->{
+    Exception exception = assertThrows(ExecutionException.class, ()-> {
       getCompleted.get(6, SECONDS);
     });
 


### PR DESCRIPTION
I replicated the original circumstances that caused EDGPATRON-97, the issue that
spawned this one.  What I discovered is that when an account has an invalid paymentStatus,
Any request for that account results in the request to mod-feesfines effectively never terminating.
So I set timeout limits on HttpClients within mod-patron.  Please let me know if 
you think the timeout should be longer/shorter than 5 seconds.  This results in mod-patron returning
a 500 error with a full description of the timeout error, including the endpoint and parameters of the 
failed request, if the request times out.  I tested this by running both modules locally, and forcing 
mod-patron to request account data from the local instance of mod-feesfines for the faulty account data.
