### PR TITLE
MODPATRON-122: Upgrade to RAML Module Builder 35.x.x.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,15 @@
-## 5.3.0 IN-PROGRESS
+## 5.4.0 IN-PROGRESS
 
-* Now checks localization settings and uses local currency code.  (MODPATRON-7)
+* Now checks localization settings and uses local currency code. (MODPATRON-7)
 * Adding timeout and error handlers for requests to external modules (MODPATRON-119)
+* Upgrade user interface to 16.0 ([MODPATRON-116](https://issues.folio.org/browse/MODPATRON-116))
+* Requires `inventory` `5.2 6.0 7.0 8.0 9.0 10.0 11.0 or 12.0`([MODPATRON-120](https://issues.folio.org/browse/MODPATRON-120))
+
+## 5.3.0 2022-06-15
+
 * Upgrade to RMB 34.0.0 (MODPATRON-114)
 * Missing statuses added (MODPATRON-22)
 * Title-level requests properly created (MODPATRON-104)
-* Upgrade user interface to 16.0([MODINV-116](https://issues.folio.org/browse/MODPATRON-116))
-* Requires `inventory` `5.2 6.0 7.0 8.0 9.0 10.0 11.0 or 12.0` ([MODPATRON-120](https://issues.folio.org/browse/MODPATRON-120))
 
 ## 5.2.0 2022-02-22
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 5.4.0 IN-PROGRESS
 
+* Upgraded RMB to 35.0.0 ([MODPATRON-122](https://issues.folio.org/browse/MODPATRON-122))
 * Now checks localization settings and uses local currency code. (MODPATRON-7)
 * Adding timeout and error handlers for requests to external modules (MODPATRON-119)
 * Upgrade user interface to 16.0 ([MODPATRON-116](https://issues.folio.org/browse/MODPATRON-116))

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aspectj.version>1.9.6</aspectj.version>
-    <raml-module-builder.version>34.0.0</raml-module-builder.version>
-    <vertx.version>4.1.4</vertx.version>
+    <raml-module-builder.version>35.0.0</raml-module-builder.version> <!-- also update vertx.version -->
+    <vertx.version>4.3.3</vertx.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aspectj.version>1.9.6</aspectj.version>
-    <raml-module-builder.version>35.0.0</raml-module-builder.version> <!-- also update vertx.version -->
-    <vertx.version>4.3.3</vertx.version>
+    <raml-module-builder.version>35.0.1</raml-module-builder.version> <!-- also update vertx.version -->
+    <vertx.version>4.3.4</vertx.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
https://issues.folio.org/browse/MODPATRON-122

Incidental problems also fixed:
- Incorrect NEWS.md data.
- Explicit Junit version (4.13.1) pulled in and is an older version than the already provided Junit managed version (5.7.0).