### PR TITLE
MODPATRON-7: adding additional permission to patron endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,6 +12,7 @@
           "permissionsRequired": ["patron.account.item.get"],
           "modulePermissions": [
             "configuration.entries.item.get",
+            "configuration.entries.collection.get",
             "users.item.get",
             "circulation.loans.collection.get",
             "circulation.requests.collection.get",


### PR DESCRIPTION
Testing revealed that the endpoint need an additional permission to search the configuration endpoint.  I'm adding it here.