### PR TITLE
MODPATRON-126: Upgrade dependencies for Orchid (RMB, Vertx, Log4j, ...)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aspectj.version>1.9.6</aspectj.version>
-    <raml-module-builder.version>35.0.1</raml-module-builder.version> <!-- also update vertx.version -->
-    <vertx.version>4.3.4</vertx.version>
+    <raml-module-builder.version>35.0.6</raml-module-builder.version> <!-- also update vertx.version -->
+    <vertx.version>4.3.8</vertx.version>
   </properties>
 
   <repositories>
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.16</version>
+      <version>1.18.26</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -144,6 +144,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -529,18 +530,9 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <!-- There is some data-time parsing issues could occurs because of global configuration to accept
-             with colon (can be changed via annotation or objects mapper config). Affected in higher versions starting from the 2.11.0 -->
-        <version>2.10.2</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.16.0</version>
+        <version>2.19.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -5,6 +5,7 @@ import static io.restassured.http.ContentType.JSON;
 import static io.restassured.http.ContentType.TEXT;
 import static org.folio.patron.utils.Utils.readMockFile;
 import static org.folio.rest.impl.Constants.JSON_FIELD_HOLDINGS_RECORD_ID;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -21,7 +22,6 @@ import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.tools.utils.ModuleName;
-import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.AfterEach;
@@ -1408,7 +1408,7 @@ public class PatronResourceImplTest {
       .log().all()
       .and().assertThat().statusCode(expectedCode)
       .and().assertThat().contentType(ContentType.TEXT)
-      .and().assertThat().body(Matchers.equalTo(codeString));
+      .and().assertThat().body(startsWith(codeString));
 
     // Test done
     logger.info("Test done");
@@ -1494,7 +1494,7 @@ public class PatronResourceImplTest {
       .log().all()
       .and().assertThat().statusCode(expectedCode)
       .and().assertThat().contentType(ContentType.TEXT)
-      .and().assertThat().body(Matchers.equalTo(codeString));
+      .and().assertThat().body(startsWith(codeString));
 
     // Test done
     logger.info("Test done");
@@ -1517,7 +1517,7 @@ public class PatronResourceImplTest {
       .log().all()
       .and().assertThat().statusCode(expectedCode)
       .and().assertThat().contentType(expectedContentType)
-      .and().assertThat().body(Matchers.equalTo(expectedMessage));
+      .and().assertThat().body(startsWith(expectedMessage));
 
     // Test done
     logger.info("Test done");


### PR DESCRIPTION
Upgrade log4j from 2.16.0 to 2.19.0. This fixes uncontrolled recursion from self-referential lookups: https://nvd.nist.gov/vuln/detail/CVE-2021-45105

Upgrade RMB from 35.0.1 to 35.0.6.
Upgrade Vert.x from 4.3.4 to 4.3.8.
Upgrade lombok from 1.18.16 to 1.18.26 (allows JDK17 to compile mod-patron).

Remove useless jackson-bom. Since mod-patron 5.0.0 the jackson version provided by vertx-stack-depchain takes precedence over the jackson-bom version and the date-time issue has been fixed:
https://issues.folio.org/browse/MODPATRON-53