### PR TITLE
MODPATRON-131 Cancelling TLRs that were created without items returns HTTP 500

### DIFF
--- a/src/main/java/org/folio/rest/impl/HoldHelpers.java
+++ b/src/main/java/org/folio/rest/impl/HoldHelpers.java
@@ -101,6 +101,7 @@ class HoldHelpers {
       .put("requestType", body.getString(JSON_FIELD_REQUEST_TYPE))
       .put("pickupServicePointId", body.getString(JSON_FIELD_PICKUP_SERVICE_POINT_ID))
       .put("patronComments", body.getString(JSON_FIELD_PATRON_COMMENTS));
+
     return addCancellationFieldsToRequest(cancelRequest, entity);
   }
 }

--- a/src/main/java/org/folio/rest/impl/HoldHelpers.java
+++ b/src/main/java/org/folio/rest/impl/HoldHelpers.java
@@ -80,9 +80,11 @@ class HoldHelpers {
 
   static JsonObject createCancelRequest(JsonObject body, Hold entity) {
     JsonObject itemJson = body.getJsonObject(JSON_FIELD_ITEM);
-    itemJson.remove(JSON_FIELD_TITLE);
-    itemJson.remove(JSON_FIELD_INSTANCE_ID);
-    itemJson.remove(JSON_FIELD_CONTRIBUTORS);
+    if (itemJson != null) {
+      itemJson.remove(JSON_FIELD_TITLE);
+      itemJson.remove(JSON_FIELD_INSTANCE_ID);
+      itemJson.remove(JSON_FIELD_CONTRIBUTORS);
+    }
 
     JsonObject cancelRequest = new JsonObject()
       .put("id", body.getString(JSON_FIELD_ID))
@@ -99,7 +101,6 @@ class HoldHelpers {
       .put("requestType", body.getString(JSON_FIELD_REQUEST_TYPE))
       .put("pickupServicePointId", body.getString(JSON_FIELD_PICKUP_SERVICE_POINT_ID))
       .put("patronComments", body.getString(JSON_FIELD_PATRON_COMMENTS));
-
     return addCancellationFieldsToRequest(cancelRequest, entity);
   }
 }

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -28,7 +28,6 @@ import static org.folio.rest.jaxrs.resource.Patron.PostPatronAccountItemHoldById
 import static org.folio.rest.jaxrs.resource.Patron.PostPatronAccountItemHoldByIdAndItemIdResponse.respond422WithApplicationJson;
 import static org.folio.rest.jaxrs.resource.Patron.PostPatronAccountItemHoldByIdAndItemIdResponse.respond500WithTextPlain;
 
-import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -58,6 +57,8 @@ import org.folio.rest.jaxrs.resource.Patron;
 import org.folio.util.StringUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+
+import com.google.common.collect.Maps;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -292,13 +293,11 @@ public class PatronServicesResourceImpl implements Patron {
     httpClient.get("/circulation/requests/" + holdId, Map.of(), okapiHeaders)
       .thenApply(ResponseInterpreter::verifyAndExtractBody)
       .thenApply(body -> {
-        final Item item = getItem(body);
-        final Hold hold = getHold(body, item);
-        holds[0] = constructNewHoldWithCancellationFields(hold, entity);
+        holds[0] = constructNewHoldWithCancellationFields(getHold(body, getItem(body)), entity);
         return body;
       })
-      .thenCompose(anUpdatedRequest -> httpClient.put("/circulation/requests/" + holdId,
-        createCancelRequest(anUpdatedRequest, entity), okapiHeaders))
+      .thenCompose(updatedRequest -> httpClient.put("/circulation/requests/" + holdId,
+        createCancelRequest(updatedRequest, entity), okapiHeaders))
       .thenApply(ResponseInterpreter::verifyAndExtractBody)
       .whenComplete((body, throwable) -> {
         if (throwable != null) {

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.rest.impl.Constants.JSON_FIELD_CONTRIBUTORS;
 import static org.folio.rest.impl.Constants.JSON_FIELD_CONTRIBUTOR_NAMES;
 import static org.folio.rest.impl.Constants.JSON_FIELD_HOLDINGS_RECORD_ID;
@@ -120,7 +121,7 @@ public class PatronServicesResourceImpl implements Patron {
                     return CompletableFuture.allOf(cfs.toArray(new CompletableFuture[cfs.size()]))
                         .thenApply(done -> account);
                   }
-                  return CompletableFuture.completedFuture(account);
+                  return completedFuture(account);
                 });
 
             return CompletableFuture.allOf(cf1, cf2, cf3)
@@ -290,7 +291,8 @@ public class PatronServicesResourceImpl implements Patron {
 
     final Hold[] holds = new Hold[1];
 
-    httpClient.get("/circulation/requests/" + holdId, Map.of(), okapiHeaders)
+    completedFuture("/circulation/requests/" + holdId)
+      .thenCompose(path -> httpClient.get(path, Map.of(), okapiHeaders))
       .thenApply(ResponseInterpreter::verifyAndExtractBody)
       .thenApply(body -> {
         holds[0] = constructNewHoldWithCancellationFields(getHold(body, getItem(body)), entity);

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
+import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.rest.impl.Constants.JSON_FIELD_CONTRIBUTORS;
 import static org.folio.rest.impl.Constants.JSON_FIELD_CONTRIBUTOR_NAMES;
@@ -70,6 +71,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class PatronServicesResourceImpl implements Patron {
+
+  private static final String CIRCULATION_REQUESTS = "/circulation/requests/%s";
 
   @Validate
   @Override
@@ -291,14 +294,14 @@ public class PatronServicesResourceImpl implements Patron {
 
     final Hold[] holds = new Hold[1];
 
-    completedFuture("/circulation/requests/" + holdId)
+    completedFuture(format(CIRCULATION_REQUESTS, holdId))
       .thenCompose(path -> httpClient.get(path, Map.of(), okapiHeaders))
       .thenApply(ResponseInterpreter::verifyAndExtractBody)
       .thenApply(body -> {
         holds[0] = constructNewHoldWithCancellationFields(getHold(body, getItem(body)), entity);
         return body;
       })
-      .thenCompose(updatedRequest -> httpClient.put("/circulation/requests/" + holdId,
+      .thenCompose(updatedRequest -> httpClient.put(format(CIRCULATION_REQUESTS, holdId),
         createCancelRequest(updatedRequest, entity), okapiHeaders))
       .thenApply(ResponseInterpreter::verifyAndExtractBody)
       .whenComplete((body, throwable) -> {
@@ -741,16 +744,16 @@ public class PatronServicesResourceImpl implements Patron {
 
   private String buildQueryWithUserId(String userId, String sortBy) {
     if(StringUtils.isNoneBlank(sortBy)) {
-      return String.format("(userId==%s and status.name==Open) sortBy %s", userId, sortBy);
+      return format("(userId==%s and status.name==Open) sortBy %s", userId, sortBy);
     }
-    return String.format("(userId==%s and status.name==Open)", userId);
+    return format("(userId==%s and status.name==Open)", userId);
   }
 
   private String buildQueryWithRequesterId(String requesterId, String sortBy) {
     if(StringUtils.isNoneBlank(sortBy)) {
-      return String.format("(requesterId==%s and status==Open*) sortBy %s", requesterId, sortBy);
+      return format("(requesterId==%s and status==Open*) sortBy %s", requesterId, sortBy);
     }
-    return String.format("(requesterId==%s and status==Open*)", requesterId);
+    return format("(requesterId==%s and status==Open*)", requesterId);
   }
 
 }

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -1385,8 +1385,6 @@ public class PatronResourceImplTest {
 
     final var expectedHold = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"));
     verifyHold(expectedHold, new JsonObject(holdCancelResponse));
-
-    // Test done
     logger.info("Test done");
   }
 

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -1365,23 +1365,23 @@ public class PatronResourceImplTest {
     aBody = jsonBody.encodePrettily();
 
     var holdCancelResponse = given()
-      .header(tenantHeader)
-      .header(urlHeader)
-      .header(new Header(okapiBadDataHeader, "hold_cancel_request_without_item"))
-      .header(contentTypeHeader)
-      .body(aBody)
-      .pathParam("accountId", goodUserId)
-      .pathParam("holdId", goodCancelHoldId)
-      .log().all()
+        .header(tenantHeader)
+        .header(urlHeader)
+        .header(new Header(okapiBadDataHeader, "hold_cancel_request_without_item"))
+        .header(contentTypeHeader)
+        .body(aBody)
+        .pathParam("accountId", goodUserId)
+        .pathParam("holdId", goodCancelHoldId)
+        .log().all()
       .when()
-      .contentType(ContentType.JSON)
-      .post(accountPath + holdPath + holdIdPath + cancelPath)
+        .contentType(ContentType.JSON)
+        .post(accountPath + holdPath + holdIdPath + cancelPath)
       .then()
-      .log().all()
-      .and().assertThat().contentType(ContentType.JSON)
-      .and().assertThat().statusCode(200)
-      .extract()
-      .asString();
+        .log().all()
+        .and().assertThat().contentType(ContentType.JSON)
+        .and().assertThat().statusCode(200)
+        .extract()
+        .asString();
 
     final var expectedHold = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"));
     verifyHold(expectedHold, new JsonObject(holdCancelResponse));

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -357,6 +357,12 @@ public class PatronResourceImplTest {
               .setStatusCode(200)
               .putHeader("content-type", "application/json")
               .end(responseBody);
+          } if (badDataValue != null && badDataValue.equals("hold_cancel_request_without_item")) {
+            String responseBody = readMockFile(mockDataFolder + "/hold_cancel_request_without_item.json");
+            req.response()
+              .setStatusCode(200)
+              .putHeader("content-type", "application/json")
+              .end(responseBody);
           } else {
             String responseBody = readMockFile(mockDataFolder + "/hold_cancel.json");
             req.response()
@@ -1344,6 +1350,41 @@ public class PatronResourceImplTest {
       holdErrorResponse.getErrors().get(0).getParameters().get(0).getKey());
     assertEquals("69f059dd-e8ad-43a9-b2d7-d35a0ad3ab1b",
       holdErrorResponse.getErrors().get(0).getParameters().get(0).getValue());
+
+    // Test done
+    logger.info("Test done");
+  }
+
+  @Test
+  public final void cancelRequestShouldNotFailWithoutItem() {
+    logger.info("Testing cancelling request without item");
+
+    String aBody = readMockFile(mockDataFolder + "/hold_cancel_request.json");
+    JsonObject jsonBody = new JsonObject(aBody);
+    jsonBody.remove("item");
+    aBody = jsonBody.encodePrettily();
+
+    var holdCancelResponse = given()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(new Header(okapiBadDataHeader, "hold_cancel_request_without_item"))
+      .header(contentTypeHeader)
+      .body(aBody)
+      .pathParam("accountId", goodUserId)
+      .pathParam("holdId", goodCancelHoldId)
+      .log().all()
+      .when()
+      .contentType(ContentType.JSON)
+      .post(accountPath + holdPath + holdIdPath + cancelPath)
+      .then()
+      .log().all()
+      .and().assertThat().contentType(ContentType.JSON)
+      .and().assertThat().statusCode(200)
+      .extract()
+      .asString();
+
+    final var expectedHold = new JsonObject(readMockFile(mockDataFolder + "/response_testPostPatronAccountByIdItemByItemIdHoldCancel.json"));
+    verifyHold(expectedHold, new JsonObject(holdCancelResponse));
 
     // Test done
     logger.info("Test done");

--- a/src/test/resources/PatronServicesResourceImpl/hold_cancel_request_without_item.json
+++ b/src/test/resources/PatronServicesResourceImpl/hold_cancel_request_without_item.json
@@ -1,0 +1,72 @@
+{
+  "id":"6d2a6f6d-d60e-427f-98fa-9d159b2920f5",
+  "requestLevel":"Title",
+  "requestType":"Hold",
+  "requestDate":"2023-03-02T00:00:00.000+00:00",
+  "patronComments":"",
+  "requesterId":"b297f9f0-d3d6-4e2b-886d-f7624a974eec",
+  "instanceId":"589edce1-51b6-4a2b-878e-d640819d0db3",
+  "status":"Open - Not yet filled",
+  "position":1,
+  "instance":{
+    "title":"A semantic web primer test",
+    "identifiers":[
+      {
+        "identifierTypeId":"8261054f-be78-422d-bd51-4ed9f33c3422",
+        "value":"0262012103"
+      },
+      {
+        "identifierTypeId":"8261054f-be78-422d-bd51-4ed9f33c3422",
+        "value":"9780262012102"
+      },
+      {
+        "identifierTypeId":"c858e4f2-2b6b-4385-842b-60732ee14abb",
+        "value":"2003065165"
+      }
+    ],
+    "contributorNames":[
+      {
+        "name":"Antoniou, Grigoris"
+      },
+      {
+        "name":"Van Harmelen, Frank"
+      }
+    ],
+    "publication":[
+      {
+        "publisher":"MIT Press",
+        "place":"Cambridge, Mass. ",
+        "dateOfPublication":"c2004",
+        "role":"Publisher"
+      }
+    ]
+  },
+  "requester":{
+    "lastName":"TestLastName",
+    "firstName":"TestFirstName",
+    "barcode":"12345",
+    "patronGroup":{
+      "id":"3684a786-6671-4268-8ed0-9db82ebca60b",
+      "group":"staff",
+      "desc":"Staff Member"
+    },
+    "patronGroupId":"3684a786-6671-4268-8ed0-9db82ebca60b"
+  },
+  "fulfilmentPreference":"Hold Shelf",
+  "requestExpirationDate":"2023-03-03T23:59:59.000+00:00",
+  "pickupServicePointId":"3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+  "metadata":{
+    "createdDate":"2023-03-02T21:25:14.046+00:00",
+    "createdByUserId":"0b0e6da6-4cd7-52c3-9225-bb710651fc15",
+    "updatedDate":"2023-03-02T21:25:15.377+00:00",
+    "updatedByUserId":"0b0e6da6-4cd7-52c3-9225-bb710651fc15"
+  },
+  "pickupServicePoint":{
+    "name":"Circ Desk 1",
+    "code":"cd1",
+    "discoveryDisplayName":"Circulation Desk -- Hallway",
+    "description":null,
+    "shelvingLagTime":null,
+    "pickupLocation":true
+  }
+}


### PR DESCRIPTION
## Purpose
- Fix cancelling TLR that were created without items returns HTTP 500

Resolves: [MODPATRON-131](https://issues.folio.org/browse/MODPATRON-131)

## Approach
- Fix NPE for cancelling request without item;
- Fix doubling response error handling; 
- Add test to cover the scenario
