### PR TITLE
MODPATRON-133: updating feefine interface to 18.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -79,7 +79,7 @@
     },
     {
       "id": "feesfines",
-      "version": "14.0 15.0 16.0 17.0"
+      "version": "14.0 15.0 16.0 17.0 18.0"
     },
     {
       "id": "inventory",


### PR DESCRIPTION
It does not look as though there are any modifications that need to be made to the actual module
code to support the change.  My understanding is that we always make version numbers inclusive if possible, 
so I've added it to the list of supported versions rather than replacing anything.