### PR TITLE
MODPATRON-147 Add allowed-service-points endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "patron",
-      "version": "5.0",
+      "version": "5.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -60,6 +60,14 @@
             "circulation.requests.item.put",
             "circulation.requests.item.get"
           ]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/patron/account/{accountId}/instance/{instanceId}/allowed-service-points",
+          "permissionsRequired": ["patron.hold.allowed-service-points.get"],
+          "modulePermissions": [
+            "circulation.requests.allowed-service-points.get"
+          ]
         }
       ]
     }
@@ -111,6 +119,11 @@
       "permissionName": "patron.hold.cancel.item.post",
       "displayName": "patron - remove a hold",
       "description": "Removes the specified hold"
+    },
+    {
+      "permissionName": "patron.hold.allowed-service-points.get",
+      "displayName": "patron - get a list of allowed service points for a hold",
+      "description": "Get a list of allowed service points for a hold"
     },
     {
       "permissionName": "patron.all",

--- a/ramls/allowed-service-point.json
+++ b/ramls/allowed-service-point.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": ["array", "null"],
+  "description": "List of allowed pickup service points",
+  "default": null,
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "UUID string",
+        "$ref": "raml-util/schemas/uuid.schema"
+      },
+      "name": {
+        "type": "string",
+        "description": "Service point name"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "name"
+    ]
+  }
+}

--- a/ramls/allowed-service-point.json
+++ b/ramls/allowed-service-point.json
@@ -18,7 +18,6 @@
         "description": "Service point name"
       }
     },
-    "additionalProperties": false,
     "required": [
       "id",
       "name"

--- a/ramls/allowed-service-points-response.json
+++ b/ramls/allowed-service-points-response.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Allowed pickup service points grouped by request type",
+  "type": "object",
+  "properties": {
+    "allowedServicePoints": {
+      "description": "Allowed pickup service point IDs for Page requests",
+      "type": "array",
+      "$ref": "allowed-service-point.json"
+    }
+  },
+  "additionalProperties": false
+}

--- a/ramls/allowed-service-points-response.json
+++ b/ramls/allowed-service-points-response.json
@@ -9,5 +9,7 @@
       "$ref": "allowed-service-point.json"
     }
   },
-  "additionalProperties": false
+  "required": [
+    "allowedServicePoints"
+  ]
 }

--- a/ramls/examples/allowed-service-points-response.json
+++ b/ramls/examples/allowed-service-points-response.json
@@ -1,0 +1,9 @@
+{
+  "allowedServicePoints" : [ {
+    "id" : "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+    "name" : "Circ Desk 1"
+  }, {
+    "id" : "c4c90014-c8c9-4ade-8f24-b5e313319f4b",
+    "name" : "Circ Desk 2"
+  } ]
+}

--- a/ramls/patron.raml
+++ b/ramls/patron.raml
@@ -2,7 +2,7 @@
 title: Patron Services
 baseUri: https://github.com/folio-org/mod-patron
 protocols: [ HTTPS ]
-version: v4.1
+version: v4.2
 
 documentation:
   - title: Patron Services

--- a/ramls/patron.raml
+++ b/ramls/patron.raml
@@ -17,6 +17,7 @@ types:
   charge: !include charge.json
   money: !include money.json
   item: !include item.json
+  allowedServicePoints: !include allowed-service-points-response.json
   errors: !include raml-util/schemas/errors.schema
   error: !include raml-util/schemas/error.schema
   parameters: !include raml-util/schemas/parameters.schema
@@ -275,6 +276,32 @@ traits:
                   body:
                     text/plain:
                       example: Optimistic Locking Conflict
+                500:
+                  description: |
+                    Internal server error, e.g. due to misconfiguration
+                  body:
+                    text/plain:
+                      example: internal server error, contact administrator
+          /allowed-service-points:
+            displayName: Allowed service points
+            description: Services that provides a list of allowed pickup service points
+            get:
+              description: |
+                Returns a list of pickup service points allowed for a particular patron and instance
+              is: [ validate ]
+              responses:
+                200:
+                  description: |
+                    Successfully returns a list of allowed service points
+                  body:
+                    application/json:
+                      type: allowedServicePoints
+                      example: !include examples/allowed-service-points-response.json
+                422:
+                  description: Validation error
+                  body:
+                    application/json:
+                      type: errors
                 500:
                   description: |
                     Internal server error, e.g. due to misconfiguration

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -800,8 +800,8 @@ public class PatronServicesResourceImpl implements Patron {
     final Future<javax.ws.rs.core.Response> result;
 
     final Throwable t = throwable.getCause();
-    if (t instanceof HttpException) {
-      final int code = ((HttpException) t).getCode();
+    if (t instanceof HttpException httpexception) {
+      final int code = httpexception.getCode();
       final String message = t.getMessage();
       if (code == 422) {
         final Errors errors = Json.decodeValue(message, Errors.class);

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -590,12 +590,8 @@ public class PatronServicesResourceImpl implements Patron {
   }
 
   private AllowedServicePoints getAllowedServicePoints(JsonObject body) {
-    JsonArray pageAllowedServicePoints = body.getJsonArray("Page");
-    JsonArray holdAllowedServicePoints = body.getJsonArray("Hold");
-    JsonArray recallAllowedServicePoints = body.getJsonArray("Recall");
-
-    Set<AllowedServicePoint> allowedSpSet = Stream.of(pageAllowedServicePoints,
-        holdAllowedServicePoints, recallAllowedServicePoints)
+    Set<AllowedServicePoint> allowedSpSet = Stream.of(body.getJsonArray("Page"),
+        body.getJsonArray("Hold"), body.getJsonArray("Recall"))
       .filter(Objects::nonNull)
       .flatMap(JsonArray::stream)
       .map(JsonObject.class::cast)

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -1598,7 +1598,7 @@ public class PatronResourceImplTest {
   }
 
   @Test
-  public final void allowedServicePointsShouldSucceed() {
+  final void allowedServicePointsShouldSucceed() {
     logger.info("Testing allowed service points");
 
     var allowedSpResponse = given()

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -8,6 +8,7 @@ import static org.folio.rest.impl.Constants.JSON_FIELD_HOLDINGS_RECORD_ID;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Objects;
@@ -72,6 +73,7 @@ public class PatronResourceImplTest {
   private final String holdIdPath = "/{holdId}";
   private final String renewPath = "/renew";
   private final String cancelPath = "/cancel";
+  private final String allowedServicePointsPath = "/allowed-service-points";
   private final String okapiBadDataHeader = "x-okapi-bad-data";
   private final String holdingsStorage = "/holdings-storage/holdings/";
 
@@ -645,7 +647,13 @@ public class PatronResourceImplTest {
           .setStatusCode(200)
           .putHeader("content-type", "application/json")
           .end(readMockFile(mockDataFolder + "/localization_settings.json"));
-      } else {
+      } else if (req.path().equals("/circulation/requests/allowed-service-points")) {
+        req.response()
+          .setStatusCode(200)
+          .putHeader("content-type", "application/json")
+          .end(readMockFile(mockDataFolder + "/allowed_sp_mod_circulation_response.json"));
+      }
+      else {
         req.response().setStatusCode(500).end("Unexpected call: " + req.path());
       }
     });
@@ -1589,6 +1597,33 @@ public class PatronResourceImplTest {
     logger.info("Test done");
   }
 
+  @Test
+  public final void allowedServicePointsShouldSucceed() {
+    logger.info("Testing allowed service points");
+
+    var allowedSpResponse = given()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .pathParam("accountId", goodUserId)
+      .pathParam("instanceId", goodInstanceId)
+      .log().all()
+      .when()
+      .contentType(ContentType.JSON)
+      .get(accountPath + instancePath + allowedServicePointsPath)
+      .then()
+      .log().all()
+      .and().assertThat().contentType(ContentType.JSON)
+      .and().assertThat().statusCode(200)
+      .extract()
+      .asString();
+
+    final JsonObject expectedJson = new JsonObject(readMockFile(mockDataFolder +
+      "/allowed_sp_mod_patron_expected_response.json"));
+    verifyAllowedServicePoints(expectedJson, new JsonObject(allowedSpResponse));
+    logger.info("Test done");
+  }
+
   static Stream<Arguments> tlrFeatureStates() {
     return Stream.of(
       Arguments.of("/response_testPostPatronAccountByIdInstanceByInstanceIdHoldNoItemId.json", true, true),
@@ -1784,5 +1819,26 @@ public class PatronResourceImplTest {
       return true;
     }
     return false;
+  }
+
+  private void verifyAllowedServicePoints(JsonObject expectedAllowedServicePoints,
+    JsonObject actualAllowedServicePoints) {
+
+    JsonArray expectedAllowedServicePointsArray = expectedAllowedServicePoints
+      .getJsonArray("allowedServicePoints");
+    JsonArray actualAllowedServicePointsArray = actualAllowedServicePoints
+      .getJsonArray("allowedServicePoints");
+
+    assertEquals(expectedAllowedServicePointsArray.size(), actualAllowedServicePointsArray.size());
+
+    expectedAllowedServicePoints.getJsonArray("allowedServicePoints").stream()
+      .map(JsonObject.class::cast)
+      .forEach(e -> {
+        boolean match = actualAllowedServicePointsArray.stream()
+          .map(JsonObject.class::cast)
+          .map(a -> a.getString("id"))
+          .anyMatch(aid -> aid.equals(e.getString("id")));
+        assertTrue(match);
+      });
   }
 }

--- a/src/test/resources/PatronServicesResourceImpl/allowed_service_points_instance_not_found.json
+++ b/src/test/resources/PatronServicesResourceImpl/allowed_service_points_instance_not_found.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "message": "Instance with ID d5a2f197-23d9-4153-9d79-da7a9f2d4a0d was not found",
+      "parameters": []
+    }
+  ]
+}

--- a/src/test/resources/PatronServicesResourceImpl/allowed_sp_mod_circulation_response.json
+++ b/src/test/resources/PatronServicesResourceImpl/allowed_sp_mod_circulation_response.json
@@ -1,0 +1,13 @@
+{
+  "Hold" : [ {
+    "id" : "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+    "name" : "Circ Desk 1"
+  }, {
+    "id" : "c4c90014-c8c9-4ade-8f24-b5e313319f4b",
+    "name" : "Circ Desk 2"
+  } ],
+  "Recall" : [ {
+    "id" : "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+    "name" : "Online"
+  } ]
+}

--- a/src/test/resources/PatronServicesResourceImpl/allowed_sp_mod_patron_expected_response.json
+++ b/src/test/resources/PatronServicesResourceImpl/allowed_sp_mod_patron_expected_response.json
@@ -1,0 +1,12 @@
+{
+  "allowedServicePoints" : [ {
+    "id" : "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+    "name" : "Circ Desk 1"
+  }, {
+    "id" : "c4c90014-c8c9-4ade-8f24-b5e313319f4b",
+    "name" : "Circ Desk 2"
+  }, {
+    "id" : "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+    "name" : "Online"
+  } ]
+}


### PR DESCRIPTION
[MODPATRON-147](https://issues.folio.org/browse/MODPATRON-147)

## Purpose
Discovery application need to know which service points are available as pickup locations.

## Approach
Reusing existing mod-circulation's endpoint and combining the result into a single list of service points (because they can't choose the request type on the discovery side).