### PR TITLE
MODPATRON-178: Fixed exception handling

### DIFF
--- a/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
+++ b/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,7 +39,7 @@ public class EcsTlrSettingsService {
   }
 
   private JsonObject handleEcsTlrSettingsFetchingError(Throwable throwable) {
-    if (throwable instanceof HttpException) {
+    if (isCompletionExceptionWithHttpCause(throwable)) {
       logger.warn("handleErrorFromModTlr:: failed to fetch ECS TLR settings from mod-tlr",
         throwable);
       return null;
@@ -74,5 +75,13 @@ public class EcsTlrSettingsService {
       .orElse(false);
     logger.debug("getCirculationStorageEcsTlrFeatureValue:: result = {}", result);
     return result;
+  }
+
+  private static boolean isCompletionExceptionWithHttpCause(Throwable throwable) {
+    if (throwable instanceof CompletionException) {
+      Throwable cause = throwable.getCause();
+      return cause instanceof HttpException;
+    }
+    return false;
   }
 }

--- a/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
+++ b/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
@@ -39,7 +39,7 @@ public class EcsTlrSettingsService {
   }
 
   private JsonObject handleEcsTlrSettingsFetchingError(Throwable throwable) {
-    if (isCompletionExceptionWithHttpCause(throwable)) {
+    if (throwable.getCause() instanceof HttpException) {
       logger.warn("handleErrorFromModTlr:: failed to fetch ECS TLR settings from mod-tlr",
         throwable);
       return null;
@@ -75,13 +75,5 @@ public class EcsTlrSettingsService {
       .orElse(false);
     logger.debug("getCirculationStorageEcsTlrFeatureValue:: result = {}", result);
     return result;
-  }
-
-  private static boolean isCompletionExceptionWithHttpCause(Throwable throwable) {
-    if (throwable instanceof CompletionException) {
-      Throwable cause = throwable.getCause();
-      return cause instanceof HttpException;
-    }
-    return false;
   }
 }

--- a/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
+++ b/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/test/java/org/folio/rest/impl/AllowedServicePointPathTest.java
+++ b/src/test/java/org/folio/rest/impl/AllowedServicePointPathTest.java
@@ -140,7 +140,7 @@ public class AllowedServicePointPathTest extends BaseResourceServiceTest {
   }
 
   @Test
-  void shouldThrowCompletionExceptionIsNotHttpException() {
+  void shouldThrowUnexpectedFetchingExceptionIsNotHttpException() {
     String responseWithErrorActual = given()
       .header(new Header(ECS_TLR_HEADER_NAME, NOT_FOUND_STATUS_HEADER_VALUE))
       .header(tenantHeader)
@@ -203,7 +203,7 @@ public class AllowedServicePointPathTest extends BaseResourceServiceTest {
           .end(EMPTY_STUB_RESPONSE);
       } else if (req.getHeader(ECS_TLR_HEADER_NAME).equals(NOT_FOUND_STATUS_HEADER_VALUE)) {
         req.response()
-          .setStatusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())
+          .setStatusCode(HttpStatus.HTTP_NOT_FOUND.toInt())
           .putHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_APPLICATION_JSON_HEADER);
       } else if (req.getHeader(ECS_TLR_HEADER_NAME).isEmpty()) {
         req.response()

--- a/src/test/java/org/folio/rest/impl/AllowedServicePointPathTest.java
+++ b/src/test/java/org/folio/rest/impl/AllowedServicePointPathTest.java
@@ -63,13 +63,19 @@ public class AllowedServicePointPathTest extends BaseResourceServiceTest {
   private static final String INSTANCE_ID_PATH_PARAM_KEY = "instanceId";
 
   private static final String INTERNAL_SERVER_ERROR_STATUS_HEADER_VALUE = "status 500";
+  private static final String NOT_FOUND_STATUS_HEADER_VALUE = "status 404";
   private static final String INTERNAL_SERVER_ERROR_STATUS_LINE =
     "HTTP/1.1 500 Internal Server Error";
-  private static final String RESPONSE_WITH_ERROR_EXPECTED =
+  private static final String ECS_TLR_RESPONSE_WITH_ERROR_EXPECTED =
     "org.folio.patron.rest.exceptions.UnexpectedFetchingException: " +
       "java.util.concurrent.CompletionException: " +
       "io.vertx.core.impl.NoStackTraceTimeoutException: The timeout period of 5000ms has been " +
       "exceeded while executing GET /tlr/settings for server null";
+  private static final String CIRCULATION_STORAGE_RESPONSE_WITH_ERROR_EXPECTED =
+    "io.vertx.core.impl.NoStackTraceTimeoutException: The timeout period of 5000ms has been " +
+      "exceeded while executing GET /circulation-settings-storage/circulation-settings for server " +
+      "null";
+  public static final String EMPTY_STUB_RESPONSE = "null";
 
   @BeforeEach
   public void setUp(Vertx vertx, VertxTestContext context) {
@@ -113,7 +119,7 @@ public class AllowedServicePointPathTest extends BaseResourceServiceTest {
   }
 
   @Test
-  void shouldThrowRuntimeExceptionIfBaseExceptionIsNotHttpException() {
+  void shouldThrowRuntimeExceptionIfBaseExceptionIsHttpException() {
     String responseWithErrorActual = given()
       .header(new Header(ECS_TLR_HEADER_NAME, INTERNAL_SERVER_ERROR_STATUS_HEADER_VALUE))
       .header(tenantHeader)
@@ -130,9 +136,27 @@ public class AllowedServicePointPathTest extends BaseResourceServiceTest {
       .extract()
       .asString();
 
-    assertEquals(RESPONSE_WITH_ERROR_EXPECTED, responseWithErrorActual);
+    assertEquals(CIRCULATION_STORAGE_RESPONSE_WITH_ERROR_EXPECTED, responseWithErrorActual);
   }
 
+  @Test
+  void shouldThrowCompletionExceptionIsNotHttpException() {
+    String responseWithErrorActual = given()
+      .header(new Header(ECS_TLR_HEADER_NAME, NOT_FOUND_STATUS_HEADER_VALUE))
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .pathParam(ACCOUNT_ID_PATH_PARAM_KEY, goodUserId)
+      .pathParam(INSTANCE_ID_PATH_PARAM_KEY, goodInstanceId)
+      .log().all()
+      .when()
+      .get(accountPath + instancePath + allowedServicePointsPath)
+      .then()
+      .extract()
+      .asString();
+
+    assertEquals(ECS_TLR_RESPONSE_WITH_ERROR_EXPECTED, responseWithErrorActual);
+  }
 
   private static Stream<Arguments> headerValueToFileName() {
     return Stream.of(
@@ -172,7 +196,12 @@ public class AllowedServicePointPathTest extends BaseResourceServiceTest {
         .end(readMockFile(MOCK_DATA_FOLDER +
           ALLOWED_SERVICE_POINTS_CIRCULATION_BFF_JSON_FILE_PATH));
     } else if (req.path().equals(ECS_TLR_SETTINGS_PATH)) {
-      if(req.getHeader(ECS_TLR_HEADER_NAME).equals(INTERNAL_SERVER_ERROR_STATUS_HEADER_VALUE)) {
+      if (req.getHeader(ECS_TLR_HEADER_NAME).equals(INTERNAL_SERVER_ERROR_STATUS_HEADER_VALUE)) {
+        req.response()
+          .setStatusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())
+          .putHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_APPLICATION_JSON_HEADER)
+          .end(EMPTY_STUB_RESPONSE);
+      } else if (req.getHeader(ECS_TLR_HEADER_NAME).equals(NOT_FOUND_STATUS_HEADER_VALUE)) {
         req.response()
           .setStatusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())
           .putHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_APPLICATION_JSON_HEADER);


### PR DESCRIPTION
Purpose:
Create URL routing between mod-circulation and mod-circulation-bff depends on ecsTlrFeatureEnabled value when "allowed service points" endpoint executed.
Jira ticket:
[MODPATRON-178](https://folio-org.atlassian.net/browse/MODPATRON-178)

