### PR TITLE
MODPATRON-192 Request types - failsafe approach for ECS requesting

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -83,7 +83,7 @@
           "permissionsRequired": ["patron.account.instance-hold.item.post"],
           "modulePermissions": [
             "circulation.requests.instances.item.post",
-            "circulation-bff.ecs-external-request.post"
+            "circulation-bff.ecs-request-external.item.post"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -82,7 +82,8 @@
           "pathPattern": "/patron/account/{accountId}/instance/{instanceId}/hold",
           "permissionsRequired": ["patron.hold.instance.item.post"],
           "modulePermissions": [
-            "circulation.requests.instances.item.post"
+            "circulation.requests.instances.item.post",
+            "circulation-bff.ecs-external-request.post"
           ]
         },
         {
@@ -146,6 +147,10 @@
     },
     {
       "id": "circulation-bff-requests",
+      "version": "1.0"
+    },
+    {
+      "id": "circulation-bff-request-external",
       "version": "1.0"
     }
   ],

--- a/src/main/java/org/folio/rest/impl/CirculationRequestService.java
+++ b/src/main/java/org/folio/rest/impl/CirculationRequestService.java
@@ -39,7 +39,7 @@ public class CirculationRequestService {
     }
 
     String url = isEcsTlrFeatureEnabled
-      ? UrlPath.URL_CIRCULATION_BFF_CREATE_REQUEST
+      ? UrlPath.CIRCULATION_BFF_CREATE_ECS_REQUEST_EXTERNAL
       : UrlPath.URL_CIRCULATION_CREATE_INSTANCE_REQUEST;
     return httpClient.post(url, hold, okapiHeaders);
   }

--- a/src/main/java/org/folio/rest/impl/UrlPath.java
+++ b/src/main/java/org/folio/rest/impl/UrlPath.java
@@ -14,6 +14,8 @@ public class UrlPath {
   public static final String CIRCULATION_SETTINGS_STORAGE_URL_PATH =
     "/circulation-settings-storage/circulation-settings";
   public static final String ECS_TLR_SETTINGS_URL_PATH ="/tlr/settings";
+  public static final String CIRCULATION_BFF_CREATE_ECS_REQUEST_EXTERNAL =
+    "/circulation-bff/create-ecs-request-external";
 
   private UrlPath() {}
 }

--- a/src/test/java/org/folio/rest/impl/AllowedServicePointPathTest.java
+++ b/src/test/java/org/folio/rest/impl/AllowedServicePointPathTest.java
@@ -27,20 +27,11 @@ import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
 public class AllowedServicePointPathTest extends BaseResourceServiceTest {
-  public static final String CONTENT_TYPE_HEADER_NAME = "content-type";
-  private static final String CONTENT_TYPE_APPLICATION_JSON_HEADER = "application/json";
   private static final String CIRCULATION_STORAGE_HEADER_NAME = "x-okapi-bad-user-id";
   private static final String ECS_TLR_HEADER_NAME = "x-okapi-bad-data";
   private static final String EMPTY_HEADER = "";
   private static final String CIRCULATION_STORAGE_ENABLED_HEADER = "circulation-storage-true";
   private static final String CIRCULATION_STORAGE_DISABLED_HEADER = "circulation-storage-false";
-  private static final String ECS_TLR_ENABLED_HEADER = "ecs-tlr-true";
-  private static final String ECS_TLR_DISABLED_HEADER = "ecs-tlr-false";
-  private static final String ECS_TLR_MOD_ENABLED_JSON_FILE_PATH =
-    "/ecs_tlr_module_feature_enabled.json";
-  private static final String ECS_TLR_MOD_DISABLED_JSON_FILE_PATH =
-    "/ecs_tlr_module_feature_disabled.json";
-  private static final String ECS_TLR_SETTINGS_PATH = "/tlr/settings";
   private static final String CIRCULATION_STORAGE_MOD_ENABLED_JSON_FILE_PATH =
     "/circulation_storage_module_feature_enabled.json";
   private static final String CIRCULATION_STORAGE_MOD_DISABLED_JSON_FILE_PATH =
@@ -59,8 +50,6 @@ public class AllowedServicePointPathTest extends BaseResourceServiceTest {
     "/circulation-bff/requests/allowed-service-points";
   private static final String SERVICE_POINTS_CIRCULATION_RESPONSE_JSON =
     "/allowed_service_points_circulation_response.json";
-  private static final String ACCOUNT_ID_PATH_PARAM_KEY = "accountId";
-  private static final String INSTANCE_ID_PATH_PARAM_KEY = "instanceId";
 
   private static final String INTERNAL_SERVER_ERROR_STATUS_HEADER_VALUE = "status 500";
   private static final String NOT_FOUND_STATUS_HEADER_VALUE = "status 404";
@@ -182,6 +171,7 @@ public class AllowedServicePointPathTest extends BaseResourceServiceTest {
     );
   }
 
+  @Override
   public void mockData(HttpServerRequest req) {
     if (req.path().equals(CIRCULATION_REQUESTS_ALLOWED_SERVICE_POINTS_PATH)) {
       req.response()

--- a/src/test/java/org/folio/rest/impl/BaseResourceServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/BaseResourceServiceTest.java
@@ -30,7 +30,19 @@ public abstract class BaseResourceServiceTest {
   protected final String accountPath = "/patron/account/{accountId}";
   protected final String instancePath = "/instance/{instanceId}";
   protected final String allowedServicePointsPath = "/allowed-service-points";
-  private final Logger logger = LogManager.getLogger();
+  protected static final String INSTANCE_ID_PATH_PARAM_KEY = "instanceId";
+  protected static final String ACCOUNT_ID_PATH_PARAM_KEY = "accountId";
+  protected static final String CONTENT_TYPE_HEADER_NAME = "content-type";
+  protected static final String CONTENT_TYPE_APPLICATION_JSON_HEADER = "application/json";
+  protected final String holdPath = "/hold";
+  protected static final String ECS_TLR_ENABLED_HEADER = "ecs-tlr-true";
+  protected static final String ECS_TLR_DISABLED_HEADER = "ecs-tlr-false";
+  protected static final String ECS_TLR_MOD_ENABLED_JSON_FILE_PATH =
+    "/ecs_tlr_module_feature_enabled.json";
+  protected static final String ECS_TLR_MOD_DISABLED_JSON_FILE_PATH =
+    "/ecs_tlr_module_feature_disabled.json";
+  protected static final String ECS_TLR_SETTINGS_PATH = "/tlr/settings";
+  protected final Logger logger = LogManager.getLogger();
 
   protected abstract void mockData(HttpServerRequest req);
 

--- a/src/test/java/org/folio/rest/impl/CirculationRequestServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/CirculationRequestServiceTest.java
@@ -24,7 +24,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
-public class CirculationRequestServiceTest extends BaseResourceServiceTest {
+class CirculationRequestServiceTest extends BaseResourceServiceTest {
 
   private static final String URL_PATH = "/patron/account/{accountId}/instance/{instanceId}/hold";
   private static final String TLR_SETTINGS_HEADER = "x-okapi-tlr-settings-header";
@@ -44,7 +44,7 @@ public class CirculationRequestServiceTest extends BaseResourceServiceTest {
     "/circulation-bff/create-ecs-request-external";
 
   @BeforeEach
-  public void setUp(Vertx vertx, VertxTestContext context) {
+  void setUp(Vertx vertx, VertxTestContext context) {
     setUpConnectionForTest(vertx, context);
     final Checkpoint mockOkapiStarted = context.checkpoint(1);
     final String host = "localhost";
@@ -54,7 +54,7 @@ public class CirculationRequestServiceTest extends BaseResourceServiceTest {
   }
 
   @AfterEach
-  public void tearDown(Vertx vertx, VertxTestContext context) {
+  void tearDown(Vertx vertx, VertxTestContext context) {
     closeConnectionForTest(vertx, context);
   }
 

--- a/src/test/java/org/folio/rest/impl/CirculationRequestServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/CirculationRequestServiceTest.java
@@ -1,0 +1,119 @@
+package org.folio.rest.impl;
+
+import static io.restassured.RestAssured.given;
+import static org.folio.patron.utils.Utils.readMockFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.folio.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.restassured.http.Header;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+public class CirculationRequestServiceTest extends BaseResourceServiceTest {
+
+  private static final String URL_PATH = "/patron/account/{accountId}/instance/{instanceId}/hold";
+  private static final String TLR_SETTINGS_HEADER = "x-okapi-tlr-settings-header";
+  private static final String TLR_SETTINGS_HEADER_ENABLED = "true";
+  private static final String TLR_SETTINGS_HEADER_DISABLED = "false";
+  private static final String TLR_CREATE_REQUEST_RESPONSE_PATH =
+    "/create_external_request_tlr_response.json";
+  private static final String CIRCULATION_CREATE_REQUEST_RESPONSE_PATH =
+    "/create_external_request_circulation_response.json";
+  private static final String TLR_POST_PATRON_ACCOUNT_RESPONSE_PATH =
+    "/post_patron_account_instance_bff.json";
+  private static final String CIRCULATION_POST_PATRON_ACCOUNT_RESPONSE_PATH =
+    "/post_patron_account_instance_circulation.json";
+  private static final String URL_CIRCULATION_CREATE_INSTANCE_REQUEST =
+    "/circulation/requests/instances";
+  private static final String CIRCULATION_BFF_CREATE_ECS_REQUEST_EXTERNAL =
+    "/circulation-bff/create-ecs-request-external";
+
+  @BeforeEach
+  public void setUp(Vertx vertx, VertxTestContext context) {
+    setUpConnectionForTest(vertx, context);
+    final Checkpoint mockOkapiStarted = context.checkpoint(1);
+    final String host = "localhost";
+    final HttpServer server = vertx.createHttpServer();
+    server.requestHandler(this::mockData);
+    server.listen(serverPort, host, context.succeeding(id -> mockOkapiStarted.flag()));
+  }
+
+  @AfterEach
+  public void tearDown(Vertx vertx, VertxTestContext context) {
+    closeConnectionForTest(vertx, context);
+  }
+
+  @Override
+  protected void mockData(HttpServerRequest req) {
+    if (req.path().equals(ECS_TLR_SETTINGS_PATH)) {
+      if (req.getHeader(TLR_SETTINGS_HEADER).equals(TLR_SETTINGS_HEADER_ENABLED)) {
+        req.response()
+          .setStatusCode(HttpStatus.HTTP_OK.toInt())
+          .putHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_APPLICATION_JSON_HEADER)
+          .end(readMockFile(MOCK_DATA_FOLDER + ECS_TLR_MOD_ENABLED_JSON_FILE_PATH));
+      } else {
+        req.response()
+          .setStatusCode(HttpStatus.HTTP_OK.toInt())
+          .putHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_APPLICATION_JSON_HEADER)
+          .end(readMockFile(MOCK_DATA_FOLDER + ECS_TLR_MOD_DISABLED_JSON_FILE_PATH));
+      }
+    } else if (req.path().equals(URL_CIRCULATION_CREATE_INSTANCE_REQUEST)) {
+      req.response()
+        .setStatusCode(HttpStatus.HTTP_OK.toInt())
+        .putHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_APPLICATION_JSON_HEADER)
+        .end(readMockFile(MOCK_DATA_FOLDER + CIRCULATION_CREATE_REQUEST_RESPONSE_PATH));
+    } else if (req.path().equals(CIRCULATION_BFF_CREATE_ECS_REQUEST_EXTERNAL)) {
+      req.response()
+        .setStatusCode(HttpStatus.HTTP_OK.toInt())
+        .putHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_APPLICATION_JSON_HEADER)
+        .end(readMockFile(MOCK_DATA_FOLDER + TLR_CREATE_REQUEST_RESPONSE_PATH));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTestData")
+  void postPatronAccountInstanceHoldByIdAndInstanceIdTest(String tlrHeaderValue,
+    String responseFileName) {
+
+    String requestBody = readMockFile(MOCK_DATA_FOLDER + "/hold_create_external_request.json");
+    var response = given()
+      .header(new Header(TLR_SETTINGS_HEADER, tlrHeaderValue))
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .pathParam(ACCOUNT_ID_PATH_PARAM_KEY, goodUserId)
+      .pathParam(INSTANCE_ID_PATH_PARAM_KEY, goodInstanceId)
+      .body(requestBody)
+      .log().all()
+      .when()
+      .post(URL_PATH)
+      .then()
+      .extract()
+      .asString();
+
+    var expectedJson = new JsonObject(readMockFile(MOCK_DATA_FOLDER + responseFileName));
+    assertEquals(expectedJson, new JsonObject(response));
+  }
+
+  private static Stream<Arguments> provideTestData() {
+    return Stream.of(
+      Arguments.of(TLR_SETTINGS_HEADER_ENABLED, TLR_POST_PATRON_ACCOUNT_RESPONSE_PATH),
+      Arguments.of(TLR_SETTINGS_HEADER_DISABLED, CIRCULATION_POST_PATRON_ACCOUNT_RESPONSE_PATH)
+    );
+  }
+}

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -109,8 +109,6 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
   private static final String REQUEST_LEVEL_TITLE = "Title";
   private static final String REQUEST_TYPE_PAGE = "Page";
   private static final String REQUEST_TYPE_HOLD = "Hold";
-
-  private boolean tlrEnabled;
   private boolean ecsTlrFeatureEnabledInTlr = false;
   private boolean ecsTlrFeatureEnabledInCirculation = false;
 
@@ -1017,7 +1015,7 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
 
     logger.info("Testing creating a hold on an instance for the specified user");
 
-    tlrEnabled = tlrState;
+    boolean tlrEnabled = tlrState;
     ecsTlrFeatureEnabledInTlr = isEcsTlrFeatureEnabledInTlr;
     ecsTlrFeatureEnabledInCirculation = isEcsTlrFeatureEnabledInCirculation;
 

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -880,7 +880,6 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
         .header(tenantHeader)
         .header(urlHeader)
         .header(contentTypeHeader)
-        .header(new Header("ABC", "ABCD"))
         .body(aBody)
         .pathParam("accountId", goodUserId)
         .pathParam("holdId", goodCancelHoldId)

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -53,7 +53,6 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
   private final Logger logger = LogManager.getLogger();
   private final String patronAccountRegistrationStatus = "/patron/registration-status";
   private final String itemPath = "/item/{itemId}";
-  private final String holdPath = "/hold";
   private final String holdIdPath = "/{holdId}";
   private final String renewPath = "/renew";
   private final String cancelPath = "/cancel";
@@ -881,6 +880,7 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
         .header(tenantHeader)
         .header(urlHeader)
         .header(contentTypeHeader)
+        .header(new Header("ABC", "ABCD"))
         .body(aBody)
         .pathParam("accountId", goodUserId)
         .pathParam("holdId", goodCancelHoldId)

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -1969,11 +1969,6 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
                 .putHeader("content-type", "text/plain")
                 .end(badDataValue);
             }
-          } else if (tlrEnabled && req.getHeader("X-Okapi-TLR-No-Item-id") != null) {
-            req.response()
-              .setStatusCode(201)
-              .putHeader("content-type", "application/json")
-              .end(readMockFile(MOCK_DATA_FOLDER + "/instance_holds_tlr_create.json"));
           } else {
             req.response()
               .setStatusCode(201)
@@ -1983,6 +1978,11 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
+      } else if (req.path().equals("/circulation-bff/create-ecs-request-external")) {
+          req.response()
+            .setStatusCode(201)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile(MOCK_DATA_FOLDER + "/instance_holds_tlr_create.json"));
       } else if (req.path().equals("/circulation/requests/" + goodCancelHoldId)) {
         final String badDataValue = req.getHeader(okapiBadDataHeader);
         if (req.method() == HttpMethod.PUT) {

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -109,6 +109,8 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
   private static final String REQUEST_LEVEL_TITLE = "Title";
   private static final String REQUEST_TYPE_PAGE = "Page";
   private static final String REQUEST_TYPE_HOLD = "Hold";
+
+  private boolean tlrEnabled;
   private boolean ecsTlrFeatureEnabledInTlr = false;
   private boolean ecsTlrFeatureEnabledInCirculation = false;
 
@@ -1009,13 +1011,11 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
 
   @ParameterizedTest
   @MethodSource("tlrFeatureStates")
-  final void testPostPatronAccountByIdInstanceByInstanceIdHold(boolean tlrState,
-    boolean noItemId, boolean isEcsTlrFeatureEnabledInTlr,
-    boolean isEcsTlrFeatureEnabledInCirculation) {
+  final void testPostPatronAccountByIdInstanceByInstanceIdHold(boolean noItemId,
+    boolean isEcsTlrFeatureEnabledInTlr, boolean isEcsTlrFeatureEnabledInCirculation) {
 
     logger.info("Testing creating a hold on an instance for the specified user");
 
-    boolean tlrEnabled = tlrState;
     ecsTlrFeatureEnabledInTlr = isEcsTlrFeatureEnabledInTlr;
     ecsTlrFeatureEnabledInCirculation = isEcsTlrFeatureEnabledInCirculation;
 
@@ -1053,14 +1053,14 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
 
   static Stream<Arguments> tlrFeatureStates() {
     return Stream.of(
-      Arguments.of(true, false, true, true),
-      Arguments.of(true, false, true, false),
-      Arguments.of(true, false, false, true),
-      Arguments.of(true, false, false, false),
-      Arguments.of(false, false, true, true),
-      Arguments.of(false, false, true, false),
-      Arguments.of(false, false, false, true),
-      Arguments.of(false, false, false, false)
+      Arguments.of( false, true, true),
+      Arguments.of( false, true, false),
+      Arguments.of( false, false, true),
+      Arguments.of( false, false, false),
+      Arguments.of( false, true, true),
+      Arguments.of( false, true, false),
+      Arguments.of( false, false, true),
+      Arguments.of( false, false, false)
     );
   }
 

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -110,7 +110,6 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
   private static final String REQUEST_TYPE_PAGE = "Page";
   private static final String REQUEST_TYPE_HOLD = "Hold";
 
-  private boolean tlrEnabled;
   private boolean ecsTlrFeatureEnabledInTlr = false;
   private boolean ecsTlrFeatureEnabledInCirculation = false;
 

--- a/src/test/resources/PatronServicesResourceImpl/create_external_request_circulation_response.json
+++ b/src/test/resources/PatronServicesResourceImpl/create_external_request_circulation_response.json
@@ -1,0 +1,14 @@
+{
+  "response": "from-tlr",
+  "status": "Open - Not yet filled",
+  "pickupServicePointId": "servicePointId",
+  "requestDate": "2024-01-01",
+  "requestDate": 2,
+  "cancellationAdditionalInformation": "cancellationAdditionalInformation",
+  "cancellationReasonId": "cancellationReasonId",
+  "cancelledByUserId": "cancelledByUserId",
+  "patronComments": "circulation-response",
+  "instance" :  {
+    "id": "instanceId"
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/create_external_request_tlr_response.json
+++ b/src/test/resources/PatronServicesResourceImpl/create_external_request_tlr_response.json
@@ -1,0 +1,14 @@
+{
+  "response": "from-tlr",
+  "status": "Open - Not yet filled",
+  "pickupServicePointId": "servicePointId",
+  "requestDate": "2024-01-01",
+  "requestDate": 2,
+  "cancellationAdditionalInformation": "cancellationAdditionalInformation",
+  "cancellationReasonId": "cancellationReasonId",
+  "cancelledByUserId": "cancelledByUserId",
+  "patronComments": "tlr-response",
+  "instance" :  {
+    "id": "instanceId"
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/hold_create_external_request.json
+++ b/src/test/resources/PatronServicesResourceImpl/hold_create_external_request.json
@@ -1,0 +1,16 @@
+{
+  "requestId": "d0f032db-9579-443e-a2ac-6add937f4aa2",
+  "item" : {
+    "itemId": "32e5757d-6566-466e-b69d-994eb33d2b73",
+    "instanceId" : "23611f0b-35cc-4f40-af09-75907d7cc421"
+  },
+  "requestDate": "2021-09-06T15:37:55.000+00:00",
+  "requestExpirationDate": "3000-01-30T08:16:30Z",
+  "fulfillmentPreference": "Hold Shelf",
+  "status": "Open - In transit",
+  "cancellationReasonId": "b548b182-55c2-4741-b169-616d9cd995a8",
+  "canceledByUserId": "ab5a5c57-491c-4b08-8f39-907810e14913",
+  "cancellationAdditionalInformation": "I don't want it anymore",
+  "canceledDate": "2021-11-06T16:23:30.262+0000",
+  "pickupLocationId": "c4c90014-c8c9-4ade-8f24-b5e313319f4b"
+}

--- a/src/test/resources/PatronServicesResourceImpl/post_patron_account_instance_bff.json
+++ b/src/test/resources/PatronServicesResourceImpl/post_patron_account_instance_bff.json
@@ -1,0 +1,10 @@
+{
+  "item" : { },
+  "requestDate" : "0002-01-03T00:00:00.000+00:00",
+  "status" : "Open - Not yet filled",
+  "pickupLocationId" : "servicePointId",
+  "cancellationReasonId" : "cancellationReasonId",
+  "canceledByUserId" : "cancelledByUserId",
+  "cancellationAdditionalInformation" : "cancellationAdditionalInformation",
+  "patronComments" : "tlr-response"
+}

--- a/src/test/resources/PatronServicesResourceImpl/post_patron_account_instance_circulation.json
+++ b/src/test/resources/PatronServicesResourceImpl/post_patron_account_instance_circulation.json
@@ -1,0 +1,10 @@
+{
+  "item" : { },
+  "requestDate" : "0002-01-03T00:00:00.000+00:00",
+  "status" : "Open - Not yet filled",
+  "pickupLocationId" : "servicePointId",
+  "cancellationReasonId" : "cancellationReasonId",
+  "canceledByUserId" : "cancelledByUserId",
+  "cancellationAdditionalInformation" : "cancellationAdditionalInformation",
+  "patronComments" : "circulation-response"
+}


### PR DESCRIPTION
## Purpose
Request types - failsafe approach for ECS requesting
## Jira ticket: 
[MODPATRON-192](https://folio-org.atlassian.net/browse/MODPATRON-192)