### PR TITLE
MODPATRON-194 Create mediated requests in secure tenant

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -74,7 +74,9 @@
             "inventory-storage.holdings.item.get",
             "users.item.get",
             "circulation.rules.request-policy.get",
-            "circulation-storage.request-policies.item.get"
+            "circulation-storage.request-policies.item.get",
+            "circulation-bff.ecs-request-external.item.post",
+            "requests-mediated.mediated-request.item.post"
           ]
         },
         {
@@ -82,7 +84,9 @@
           "pathPattern": "/patron/account/{accountId}/instance/{instanceId}/hold",
           "permissionsRequired": ["patron.account.instance-hold.item.post"],
           "modulePermissions": [
-            "circulation.requests.instances.item.post"
+            "circulation.requests.instances.item.post",
+            "circulation-bff.ecs-request-external.item.post",
+            "requests-mediated.mediated-request.item.post"
           ]
         },
         {
@@ -145,8 +149,12 @@
       "version": "1.0"
     },
     {
-      "id": "circulation-bff-requests",
+      "id": "circulation-bff-request-external",
       "version": "1.0"
+    },
+    {
+      "id": "requests-mediated",
+      "version": "2.0"
     }
   ],
   "permissionSets": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "patron",
-      "version": "6.1",
+      "version": "6.2",
       "handlers": [
         {
           "methods": ["POST"],

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,12 @@
       <version>2.25.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <version>2.1.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/ramls/hold.json
+++ b/ramls/hold.json
@@ -32,6 +32,7 @@
         "Open - Awaiting pickup",
         "Open - Awaiting delivery",
         "Open - In transit",
+        "New - Awaiting confirmation",
         "Closed - Filled",
         "Closed - Cancelled",
         "Closed - Unfilled",

--- a/src/main/java/org/folio/rest/impl/CirculationRequestService.java
+++ b/src/main/java/org/folio/rest/impl/CirculationRequestService.java
@@ -10,7 +10,6 @@ import org.folio.integration.http.VertxOkapiHttpClient;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static java.lang.System.getProperty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.folio.rest.impl.Constants.JSON_FIELD_FULFILLMENT_PREFERENCE;
 import static org.folio.rest.impl.Constants.JSON_FIELD_REQUEST_LEVEL;
@@ -73,14 +72,11 @@ public class CirculationRequestService {
   }
 
   private static boolean isTenantSecure(Map<String, String> okapiHeaders) {
-    String secureProperty = getProperty(SECURE_TENANT_ID, EMPTY);
-    log.info("isTenantSecure:: secureProperty: {}", secureProperty);
+    String secureTenantId = System.getenv().getOrDefault(SECURE_TENANT_ID, EMPTY);
+    log.info("isTenantSecure:: SECURE_TENANT_ID: {}", secureTenantId);
     String tenantFromHeaders = okapiHeaders.get(OKAPI_TENANT);
     log.info("isTenantSecure:: tenantFromHeaders: {}", tenantFromHeaders);
 
-    var result = getProperty(SECURE_TENANT_ID, EMPTY).equals(tenantFromHeaders);
-    log.info("isModuleSecure:: result: {}", result);
-
-    return result;
+    return secureTenantId.equals(tenantFromHeaders);
   }
 }

--- a/src/main/java/org/folio/rest/impl/CirculationRequestService.java
+++ b/src/main/java/org/folio/rest/impl/CirculationRequestService.java
@@ -33,7 +33,7 @@ public class CirculationRequestService {
       isEcsTlrFeatureEnabled, hold);
 
     return httpClient.post(defineUrlForRequest(isEcsTlrFeatureEnabled,
-      isModuleSecure(okapiHeaders), false), hold, okapiHeaders);
+      isTenantSecure(okapiHeaders), false), hold, okapiHeaders);
   }
 
   public static CompletableFuture<Response> createTitleLevelRequest(
@@ -51,7 +51,7 @@ public class CirculationRequestService {
     }
 
     return httpClient.post(defineUrlForRequest(isEcsTlrFeatureEnabled,
-      isModuleSecure(okapiHeaders), true), hold, okapiHeaders);
+      isTenantSecure(okapiHeaders), true), hold, okapiHeaders);
   }
 
   private static String defineUrlForRequest(boolean isEcsTlrFeatureEnabled,
@@ -61,6 +61,7 @@ public class CirculationRequestService {
       "isModuleSecure: {}, isTitleLevel: {}", isEcsTlrFeatureEnabled, isModuleSecure, isTitleLevel);
 
     if (isEcsTlrFeatureEnabled) {
+      log.info("defineUrlForRequest:: ecsTlrFeature enabled");
       return isModuleSecure
         ? UrlPath.CREATE_MEDIATED_REQUEST_URL
         : UrlPath.CIRCULATION_BFF_CREATE_ECS_REQUEST_EXTERNAL;
@@ -71,7 +72,15 @@ public class CirculationRequestService {
       : UrlPath.URL_CIRCULATION_CREATE_ITEM_REQUEST;
   }
 
-  private static boolean isModuleSecure(Map<String, String> okapiHeaders) {
-    return getProperty(SECURE_TENANT_ID, EMPTY).equals(okapiHeaders.get(OKAPI_TENANT));
+  private static boolean isTenantSecure(Map<String, String> okapiHeaders) {
+    String secureProperty = getProperty(SECURE_TENANT_ID, EMPTY);
+    log.info("isTenantSecure:: secureProperty: {}", secureProperty);
+    String tenantFromHeaders = okapiHeaders.get(OKAPI_TENANT);
+    log.info("isTenantSecure:: tenantFromHeaders: {}", tenantFromHeaders);
+
+    var result = getProperty(SECURE_TENANT_ID, EMPTY).equals(tenantFromHeaders);
+    log.info("isModuleSecure:: result: {}", result);
+
+    return result;
   }
 }

--- a/src/main/java/org/folio/rest/impl/CirculationRequestService.java
+++ b/src/main/java/org/folio/rest/impl/CirculationRequestService.java
@@ -1,18 +1,26 @@
 package org.folio.rest.impl;
 
 import io.vertx.core.json.JsonObject;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.integration.http.Response;
 import org.folio.integration.http.VertxOkapiHttpClient;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.System.getProperty;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.folio.rest.impl.Constants.JSON_FIELD_FULFILLMENT_PREFERENCE;
 import static org.folio.rest.impl.Constants.JSON_FIELD_REQUEST_LEVEL;
 import static org.folio.rest.impl.Constants.JSON_FIELD_REQUEST_TYPE;
 import static org.folio.rest.impl.Constants.JSON_VALUE_HOLD_SHELF;
 
 public class CirculationRequestService {
+  private static final Logger log = LogManager.getLogger();
+  private static final String OKAPI_TENANT = "x-okapi-tenant";
+  private static final String SECURE_TENANT_ID = "SECURE_TENANT_ID";
 
   private CirculationRequestService() {
   }
@@ -21,15 +29,19 @@ public class CirculationRequestService {
     boolean isEcsTlrFeatureEnabled, JsonObject hold,
     VertxOkapiHttpClient httpClient, Map<String, String> okapiHeaders) {
 
-    String url = isEcsTlrFeatureEnabled
-      ? UrlPath.URL_CIRCULATION_BFF_CREATE_REQUEST
-      : UrlPath.URL_CIRCULATION_CREATE_ITEM_REQUEST;
-    return httpClient.post(url, hold, okapiHeaders);
+    log.debug("createItemLevelRequest:: parameters isEcsTlrFeatureEnabled: {}, hold: {}",
+      isEcsTlrFeatureEnabled, hold);
+
+    return httpClient.post(defineUrlForRequest(isEcsTlrFeatureEnabled,
+      isModuleSecure(okapiHeaders), false), hold, okapiHeaders);
   }
 
   public static CompletableFuture<Response> createTitleLevelRequest(
     boolean isEcsTlrFeatureEnabled, JsonObject hold,
     VertxOkapiHttpClient httpClient, Map<String, String> okapiHeaders) {
+
+    log.debug("createTitleLevelRequest:: parameters isEcsTlrFeatureEnabled: {}, hold: {}",
+      isEcsTlrFeatureEnabled, hold);
 
     if (isEcsTlrFeatureEnabled) {
       hold
@@ -38,10 +50,28 @@ public class CirculationRequestService {
         .put(JSON_FIELD_FULFILLMENT_PREFERENCE, JSON_VALUE_HOLD_SHELF);
     }
 
-    String url = isEcsTlrFeatureEnabled
-      ? UrlPath.URL_CIRCULATION_BFF_CREATE_REQUEST
-      : UrlPath.URL_CIRCULATION_CREATE_INSTANCE_REQUEST;
-    return httpClient.post(url, hold, okapiHeaders);
+    return httpClient.post(defineUrlForRequest(isEcsTlrFeatureEnabled,
+      isModuleSecure(okapiHeaders), true), hold, okapiHeaders);
   }
 
+  private static String defineUrlForRequest(boolean isEcsTlrFeatureEnabled,
+    boolean isModuleSecure, boolean isTitleLevel) {
+
+    log.debug("defineUrlForRequest:: parameters isEcsTlrFeatureEnabled: {}, " +
+      "isModuleSecure: {}, isTitleLevel: {}", isEcsTlrFeatureEnabled, isModuleSecure, isTitleLevel);
+
+    if (isEcsTlrFeatureEnabled) {
+      return isModuleSecure
+        ? UrlPath.CREATE_MEDIATED_REQUEST_URL
+        : UrlPath.CIRCULATION_BFF_CREATE_ECS_REQUEST_EXTERNAL;
+    }
+
+    return isTitleLevel
+      ? UrlPath.URL_CIRCULATION_CREATE_INSTANCE_REQUEST
+      : UrlPath.URL_CIRCULATION_CREATE_ITEM_REQUEST;
+  }
+
+  private static boolean isModuleSecure(Map<String, String> okapiHeaders) {
+    return getProperty(SECURE_TENANT_ID, EMPTY).equals(okapiHeaders.get(OKAPI_TENANT));
+  }
 }

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+`import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/PatronServicesResourceImpl.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-`import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/org/folio/rest/impl/UrlPath.java
+++ b/src/main/java/org/folio/rest/impl/UrlPath.java
@@ -5,8 +5,6 @@ public class UrlPath {
     "/circulation/requests/allowed-service-points";
   public static final String CIRCULATION_BFF_ALLOWED_SERVICE_POINTS_URL_PATH =
     "/circulation-bff/requests/allowed-service-points";
-  public static final String URL_CIRCULATION_BFF_CREATE_REQUEST =
-    "/circulation-bff/requests";
   public static final String URL_CIRCULATION_CREATE_ITEM_REQUEST =
     "/circulation/requests";
   public static final String URL_CIRCULATION_CREATE_INSTANCE_REQUEST =
@@ -14,6 +12,10 @@ public class UrlPath {
   public static final String CIRCULATION_SETTINGS_STORAGE_URL_PATH =
     "/circulation-settings-storage/circulation-settings";
   public static final String ECS_TLR_SETTINGS_URL_PATH ="/tlr/settings";
+  public static final String CREATE_MEDIATED_REQUEST_URL =
+    "/requests-mediated/mediated-requests";
+  public static final String CIRCULATION_BFF_CREATE_ECS_REQUEST_EXTERNAL =
+    "/circulation-bff/create-ecs-request-external";
 
   private UrlPath() {}
 }

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -28,7 +28,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -761,9 +761,10 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
     final String body = r.getBody().asString();
     final JsonObject json = new JsonObject(body);
     final JsonObject expectedJson = new JsonObject(readMockFile(MOCK_DATA_FOLDER +
-      "/response_testPostPatronAccountByIdItemByItemIdHold.json"));
+      "/response_testPostPatronAccountByIdItemByItemIdHoldMedRequest.json"));
 
     verifyRequests(expectedJson, json);
+    System.setProperty("SECURE_TENANT_ID", "");
   }
 
   static Stream<Arguments> itemRequestsParams() {
@@ -2430,7 +2431,7 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
               .end("A random exception occurred");
           }
         });
-      } else if (req.method() == HttpMethod.POST && req.uri().equals("/circulation-bff/requests")) {
+      } else if (req.method() == HttpMethod.POST && req.uri().equals("/circulation-bff/create-ecs-request-external")) {
         req.bodyHandler(buffer -> {
           JsonObject request  = new JsonObject(buffer);
           String requestLevel = request.getString("requestLevel");
@@ -2467,7 +2468,7 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
             req.response()
               .setStatusCode(201)
               .putHeader("content-type", "application/json")
-              .end(readMockFile(MOCK_DATA_FOLDER + "/mediatedRequest_itemLevel_hold.json"));
+              .end(readMockFile(MOCK_DATA_FOLDER + "/mediatedRequest_itemLevel_hold_response.json"));
           } else if (REQUEST_LEVEL_TITLE.equals(requestLevel)) {
             req.response()
               .setStatusCode(201)

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -752,7 +752,7 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
     assertThat(System.getenv(SECURE_TENANT_VARIABLE), is(TENANT));
     ecsTlrFeatureEnabledInTlr = true;
 
-    final Response r = given()
+    final Response response = given()
       .log().all()
       .header(tenantHeader)
       .header(urlHeader)
@@ -768,7 +768,7 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
       .statusCode(201)
       .extract().response();
 
-    final String body = r.getBody().asString();
+    final String body = response.getBody().asString();
     final JsonObject json = new JsonObject(body);
     final JsonObject expectedJson = new JsonObject(readMockFile(MOCK_DATA_FOLDER +
       "/response_testPostPatronAccountByIdItemByItemIdHoldMedRequest.json"));

--- a/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronResourceImplTest.java
@@ -119,7 +119,6 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
   static {
     System.setProperty("vertx.logger-delegate-factory-class-name",
       "io.vertx.core.logging.Log4j2LogDelegateFactory");
-//    System.setProperty("SECURE_TENANT_ID", "patronresourceimpltest");
   }
 
   @BeforeEach
@@ -738,7 +737,7 @@ public class PatronResourceImplTest extends BaseResourceServiceTest {
   }
 
   @Test
-  final void postPatronAccountItemHoldByIdAndItemIdShouldCallRequestMediatedIfTenantIsSecure() {
+  final void postPatronAccountItemHoldByIdShouldCallRequestMediatedIfTenantIsSecure() {
     System.setProperty("SECURE_TENANT_ID", "patronresourceimpltest");
     ecsTlrFeatureEnabledInTlr = true;
 

--- a/src/test/resources/PatronServicesResourceImpl/mediatedRequest_itemLevel_hold.json
+++ b/src/test/resources/PatronServicesResourceImpl/mediatedRequest_itemLevel_hold.json
@@ -1,0 +1,41 @@
+{
+  "requestLevel": "Item",
+  "requestType": "Hold",
+  "requestDate": "2024-11-30T00:12:00Z",
+  "patronComments": "Test comment",
+  "requesterId": "3c22820f-4a05-4b92-a50c-de4d433fb630",
+  "requester": {
+    "firstName": "TestName",
+    "lastName": "TestLastName",
+    "barcode": "1"
+  },
+  "instanceId": "d637a57b-fbc0-4478-b929-eb528a46c696",
+  "instance": {
+    "title": "Test instance",
+    "identifiers": []
+  },
+  "holdingsRecordId": "77aad88f-40a1-4073-b00c-16b055a79ccd",
+  "itemId": "fe77e7b8-effd-4cbd-8034-90cb1cb24e1a",
+  "item": {
+    "barcode": "1"
+  },
+  "mediatedWorkflow": "Private request",
+  "status": "New - Awaiting confirmation",
+  "cancellationReasonId": null,
+  "cancelledByUserId": null,
+  "cancellationAdditionalInformation": null,
+  "cancelledDate": null,
+  "position": 1,
+  "fulfillmentPreference": "Hold Shelf",
+  "deliveryAddressTypeId": null,
+  "pickupServicePointId": "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+  "searchIndex": {
+    "callNumberComponents": {
+      "callNumber": "F16.H37 A2 9001",
+      "prefix": "pre",
+      "suffix": "suf"
+    },
+    "shelvingOrder": "F 416 H37 A2 59001",
+    "pickupServicePointName": "Circ Desk 1"
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/mediatedRequest_itemLevel_hold.json
+++ b/src/test/resources/PatronServicesResourceImpl/mediatedRequest_itemLevel_hold.json
@@ -1,23 +1,23 @@
 {
   "requestLevel": "Item",
   "requestType": "Hold",
-  "requestDate": "2024-11-30T00:12:00Z",
-  "patronComments": "Test comment",
-  "requesterId": "3c22820f-4a05-4b92-a50c-de4d433fb630",
+  "requestDate": "2024-10-14T00:12:00Z",
+  "patronComments": "My comment",
+  "requesterId": "9addcbc1-20c3-4dbb-965f-3df73fe8fa9f",
   "requester": {
-    "firstName": "TestName",
-    "lastName": "TestLastName",
+    "firstName": "Roman",
+    "lastName": "Barannyk",
     "barcode": "1"
   },
-  "instanceId": "d637a57b-fbc0-4478-b929-eb528a46c696",
+  "instanceId": "7a767f78-0bfb-426d-b41b-829c2cd6d7a0",
   "instance": {
-    "title": "Test instance",
+    "title": "Roman's instance 2",
     "identifiers": []
   },
-  "holdingsRecordId": "77aad88f-40a1-4073-b00c-16b055a79ccd",
-  "itemId": "fe77e7b8-effd-4cbd-8034-90cb1cb24e1a",
+  "holdingsRecordId": "2cb61b4e-1425-4e1d-b741-f1cced796e4d",
+  "itemId": "1d33f2c2-11a8-498c-ada1-73a5435bfd2f",
   "item": {
-    "barcode": "1"
+    "barcode": "112"
   },
   "mediatedWorkflow": "Private request",
   "status": "New - Awaiting confirmation",

--- a/src/test/resources/PatronServicesResourceImpl/mediatedRequest_itemLevel_hold_response.json
+++ b/src/test/resources/PatronServicesResourceImpl/mediatedRequest_itemLevel_hold_response.json
@@ -1,0 +1,59 @@
+{
+  "id": "8e3964a9-9937-4c44-9208-a369e93958c0",
+  "requestLevel": "Item",
+  "requestType": "Hold",
+  "requestDate": "2024-10-14T00:12:00.000+00:00",
+  "patronComments": "My comment",
+  "requesterId": "9addcbc1-20c3-4dbb-965f-3df73fe8fa9f",
+  "requester": {
+    "firstName": "Roman",
+    "lastName": "Barannyk",
+    "barcode": "1",
+    "patronGroupId": "3684a786-6671-4268-8ed0-9db82ebca60b",
+    "patronGroup": {
+      "id": "3684a786-6671-4268-8ed0-9db82ebca60b",
+      "group": "staff",
+      "desc": "Staff Member"
+    }
+  },
+  "instanceId": "7a767f78-0bfb-426d-b41b-829c2cd6d7a0",
+  "instance": {
+    "title": "Roman's instance 2",
+    "identifiers": [],
+    "contributorNames": [],
+    "publication": [],
+    "editions": [],
+    "hrid": "in00000000007"
+  },
+  "holdingsRecordId": "2cb61b4e-1425-4e1d-b741-f1cced796e4d",
+  "itemId": "1d33f2c2-11a8-498c-ada1-73a5435bfd2f",
+  "item": {
+    "barcode": "112",
+    "location": {
+      "name": "college_location",
+      "libraryName": "college_library",
+      "code": "001"
+    },
+    "status": "Available",
+    "callNumberComponents": {}
+  },
+  "mediatedWorkflow": "Private request",
+  "mediatedRequestStatus": "New",
+  "mediatedRequestStep": "Awaiting confirmation",
+  "status": "New - Awaiting confirmation",
+  "position": 1,
+  "fulfillmentPreference": "Hold Shelf",
+  "pickupServicePointId": "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+  "pickupServicePoint": {
+    "name": "Circ Desk 1",
+    "code": "cd1",
+    "discoveryDisplayName": "Circulation Desk -- Hallway",
+    "pickupLocation": true
+  },
+  "metadata": {
+    "createdDate": "2024-12-03T12:40:49.050+00:00",
+    "createdByUserId": "18e17842-c800-43f9-b6e7-c9c8ea8d795e",
+    "updatedDate": "2024-12-03T12:40:49.050+00:00",
+    "updatedByUserId": "18e17842-c800-43f9-b6e7-c9c8ea8d795e"
+  }
+}

--- a/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdItemByItemIdHoldMedRequest.json
+++ b/src/test/resources/PatronServicesResourceImpl/response_testPostPatronAccountByIdItemByItemIdHoldMedRequest.json
@@ -1,0 +1,13 @@
+{
+  "requestId":"8e3964a9-9937-4c44-9208-a369e93958c0",
+  "item":{
+    "instanceId":"7a767f78-0bfb-426d-b41b-829c2cd6d7a0",
+    "itemId":"1d33f2c2-11a8-498c-ada1-73a5435bfd2f",
+    "title":"Roman's instance 2"
+  },
+  "requestDate":"2024-10-14T00:12:00.000+00:00",
+  "status":"New - Awaiting confirmation",
+  "pickupLocationId":"3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+  "queuePosition":1,
+  "patronComments":"My comment"
+}


### PR DESCRIPTION
## Purpose

Locate should be able to create mediated requests in the secure tenant. Chain of calls:
mod-patron (secure tenant) → mod-requests-mediated (same tenant, secure)
Check if we’re in the secure tenant (use env var SECURE_TENANT_ID)
If we are, create a mediated request in mod-requests-mediated instead of a regular request in mod-circulation

Resolves: [MODPATRON-194](https://folio-org.atlassian.net/browse/MODPATRON-194)
