### PR TITLE
MODPATRON-219 Fix IndexOutOfBounds exception for single tenant environment

### DIFF
--- a/src/main/java/org/folio/integration/http/ResponseInterpreter.java
+++ b/src/main/java/org/folio/integration/http/ResponseInterpreter.java
@@ -4,14 +4,18 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.concurrent.CompletionException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.patron.rest.exceptions.HttpException;
 
 import io.vertx.core.json.JsonObject;
 
 public class ResponseInterpreter {
+  private static final Logger log = LogManager.getLogger();
   private ResponseInterpreter() {}
 
   public static JsonObject verifyAndExtractBody(Response response) {
+    log.info("verifyAndExtractBody:: response: {}", response);
     if (!response.isSuccess()) {
       throw new CompletionException(new HttpException(response.statusCode,
         response.body));
@@ -19,6 +23,7 @@ public class ResponseInterpreter {
 
     // Parsing an empty body to JSON causes an exception
     if (isBlank(response.body)) {
+      log.info("verifyAndExtractBody:: response is empty");
       return null;
     }
     return new JsonObject(response.body);

--- a/src/main/java/org/folio/integration/http/ResponseInterpreter.java
+++ b/src/main/java/org/folio/integration/http/ResponseInterpreter.java
@@ -15,7 +15,7 @@ public class ResponseInterpreter {
   private ResponseInterpreter() {}
 
   public static JsonObject verifyAndExtractBody(Response response) {
-    log.info("verifyAndExtractBody:: statusCode: {}, body: {}", response.statusCode, response.body);
+    log.info("verifyAndExtractBody:: statusCode: {}", response.statusCode);
     if (!response.isSuccess()) {
       throw new CompletionException(new HttpException(response.statusCode,
         response.body));

--- a/src/main/java/org/folio/integration/http/ResponseInterpreter.java
+++ b/src/main/java/org/folio/integration/http/ResponseInterpreter.java
@@ -15,7 +15,7 @@ public class ResponseInterpreter {
   private ResponseInterpreter() {}
 
   public static JsonObject verifyAndExtractBody(Response response) {
-    log.info("verifyAndExtractBody:: response: {}", response);
+    log.info("verifyAndExtractBody:: statusCode: {}, body: {}", response.statusCode, response.body);
     if (!response.isSuccess()) {
       throw new CompletionException(new HttpException(response.statusCode,
         response.body));

--- a/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
+++ b/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
@@ -31,7 +31,7 @@ public class EcsTlrSettingsService {
   public CompletableFuture<Boolean> isEcsTlrFeatureEnabled(VertxOkapiHttpClient httpClient,
     Map<String, String> okapiHeaders) {
 
-    logger.info("isEcsTlrFeatureEnabled:: trying to get isEcsTlrFeatureEnabled from mod-tlr");
+    logger.info("isEcsTlrFeatureEnabled:: fetching ECS request settings from /tlr/settings");
     return httpClient.get(ECS_TLR_SETTINGS_URL_PATH, okapiHeaders)
       .thenApply(ResponseInterpreter::verifyAndExtractBody)
       .exceptionally(this::handleEcsTlrSettingsFetchingError)
@@ -41,8 +41,8 @@ public class EcsTlrSettingsService {
 
   private JsonObject handleEcsTlrSettingsFetchingError(Throwable throwable) {
     if (throwable.getCause() instanceof HttpException) {
-      logger.warn("handleErrorFromModTlr:: failed to fetch ECS TLR settings from mod-tlr: {}",
-        throwable.getMessage());
+      logger.info("handleErrorFromModTlr:: failed to fetch ECS request settings from " +
+        "/tlr/settings: {}", throwable.getMessage());
       return null;
     }
     logger.error(throwable);
@@ -61,14 +61,14 @@ public class EcsTlrSettingsService {
   private CompletableFuture<Boolean> getCirculationStorageEcsTlrFeatureValue(
     VertxOkapiHttpClient client, Map<String, String> okapiHeaders) {
 
-    logger.info("getCirculationStorageEcsTlrFeatureValue:: trying to get isEcsTlrFeatureEnabled");
+    logger.info("getCirculationStorageEcsTlrFeatureValue:: fetching ECS request settings from" +
+      "/circulation-settings-storage/circulation-settings");
     return client.get(CIRCULATION_SETTINGS_STORAGE_URL_PATH, okapiHeaders)
       .thenApply(ResponseInterpreter::verifyAndExtractBody)
       .thenApply(this::getCirculationStorageEcsTlrFeatureValue);
   }
 
   private boolean getCirculationStorageEcsTlrFeatureValue(JsonObject body) {
-    logger.info("getCirculationStorageEcsTlrFeatureValue:: body: {}", () -> body);
     boolean isEcsFeatureEnabled = Optional.ofNullable(body)
       .map(json -> json.getJsonArray(CIRCULATION_SETTINGS_KEY))
       .filter(jsonArray -> !jsonArray.isEmpty())
@@ -76,7 +76,7 @@ public class EcsTlrSettingsService {
       .map(json -> json.getJsonObject(VALUE_KEY))
       .map(json -> json.getBoolean(ENABLED_KEY))
       .orElse(false);
-    logger.debug("getCirculationStorageEcsTlrFeatureValue:: result = {}", isEcsFeatureEnabled);
+    logger.info("getCirculationStorageEcsTlrFeatureValue:: result = {}", isEcsFeatureEnabled);
 
     return isEcsFeatureEnabled;
   }

--- a/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
+++ b/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
@@ -67,16 +67,17 @@ public class EcsTlrSettingsService {
       .thenApply(this::getCirculationStorageEcsTlrFeatureValue);
   }
 
-  private Boolean getCirculationStorageEcsTlrFeatureValue(JsonObject body) {
+  private boolean getCirculationStorageEcsTlrFeatureValue(JsonObject body) {
     logger.info("getCirculationStorageEcsTlrFeatureValue:: body: {}", () -> body);
-    Boolean result = Optional.ofNullable(body)
+    boolean isEcsFeatureEnabled = Optional.ofNullable(body)
       .map(json -> json.getJsonArray(CIRCULATION_SETTINGS_KEY))
       .filter(jsonArray -> !jsonArray.isEmpty())
       .map(json -> json.getJsonObject(FIRST_POSITION_INDEX))
       .map(json -> json.getJsonObject(VALUE_KEY))
       .map(json -> json.getBoolean(ENABLED_KEY))
       .orElse(false);
-    logger.debug("getCirculationStorageEcsTlrFeatureValue:: result = {}", result);
-    return result;
+    logger.debug("getCirculationStorageEcsTlrFeatureValue:: result = {}", isEcsFeatureEnabled);
+
+    return isEcsFeatureEnabled;
   }
 }

--- a/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
+++ b/src/main/java/org/folio/rest/impl/EcsTlrSettingsService.java
@@ -71,9 +71,10 @@ public class EcsTlrSettingsService {
     logger.info("getCirculationStorageEcsTlrFeatureValue:: body: {}", () -> body);
     Boolean result = Optional.ofNullable(body)
       .map(json -> json.getJsonArray(CIRCULATION_SETTINGS_KEY))
-      .flatMap(jsonArray -> Optional.ofNullable(jsonArray.getJsonObject(FIRST_POSITION_INDEX)))
-      .flatMap(json -> Optional.ofNullable(json.getJsonObject(VALUE_KEY)))
-      .map(jsonObject -> jsonObject.getBoolean(ENABLED_KEY))
+      .filter(jsonArray -> !jsonArray.isEmpty())
+      .map(json -> json.getJsonObject(FIRST_POSITION_INDEX))
+      .map(json -> json.getJsonObject(VALUE_KEY))
+      .map(json -> json.getBoolean(ENABLED_KEY))
       .orElse(false);
     logger.debug("getCirculationStorageEcsTlrFeatureValue:: result = {}", result);
     return result;


### PR DESCRIPTION
## Purpose
Fix IndexOutOfBounds exception that occurs when processing the feature toggle during the call to the 'circulation-settings-storage/circulation-settings' endpoint on single tenant environment

Resolves: [MODPATRON-219](https://folio-org.atlassian.net/browse/MODPATRON-219)