### PR TITLE
MODPATRON-229: Fix required interface name

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -156,7 +156,7 @@
       "version": "1.0"
     },
     {
-      "id": "circulation-bff-request-external",
+      "id": "circulation-bff-ecs-request-external",
       "version": "1.1"
     },
     {


### PR DESCRIPTION
Fix incorrect required interface name: `circulation-bff-request-external` -> `circulation-bff-ecs-request-external`.
[MODPATRON-229](https://folio-org.atlassian.net/browse/MODPATRON-229)